### PR TITLE
[WIP] Benchmarks and optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Manifest.toml
 docs/build/
+benchmark/results/

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,39 @@
+using BenchmarkTools
+using PauliStrings
+
+SUITE = BenchmarkGroup()
+
+# Lanczos benchmarks
+# ------------------
+# XX hamiltonian: 1d chain with XX + YY interaction
+function XX(N)
+    H = PauliStrings.Operator(N)
+    for j in 1:(N-1)
+        H += "X", j, "X", j + 1
+        H += "Z", j, "Z", j + 1
+    end
+    return H
+end
+
+# X local operator: X operator on each site
+function X(N)
+    H = PauliStrings.Operator(N)
+    for j in 1:N
+        H += "X", j
+    end
+    return H
+end
+
+
+N = 50
+g = addgroup!(SUITE, "lanczos (N=$N)")
+H = XX(N)
+O = X(N)
+steps = 20
+
+for p in 14:2:20
+    nterms = 2^p
+    g["nterms=2^$p"] = @benchmarkable PauliStrings.lanczos($H, $O, $steps, $nterms; keepnorm=true)
+end
+
+

--- a/src/PauliStrings.jl
+++ b/src/PauliStrings.jl
@@ -1,6 +1,6 @@
 module PauliStrings
 
-export Operator, OperatorTS1D, Operator64, Operator128, OperatorTS1D64, OperatorTS1D128
+export Operator, OperatorTS1D, Operator64, Operator128, OperatorTS1D64, OperatorTS1D128, OperatorSorted
 export trace, opnorm, eye, dagger, com, add, compress, ptrace, shift_left, shift, com, rotate
 export diag, xcount, ycount, zcount
 export truncate, trim, cutoff, prune, add_noise, k_local_part, participation
@@ -27,6 +27,7 @@ rng = MersenneTwister(0)
 
 include("operator.jl")
 include("operatorts1d.jl")
+include("operatorssorted.jl")
 include("io.jl")
 include("operations.jl")
 include("lanczos.jl")

--- a/src/PauliStrings.jl
+++ b/src/PauliStrings.jl
@@ -1,6 +1,6 @@
 module PauliStrings
 
-export Operator, OperatorTS1D, Operator64, Operator128, OperatorTS1D64, OperatorTS1D128, OperatorSorted
+export Operator, OperatorTS1D, Operator64, Operator128, OperatorTS1D64, OperatorTS1D128, OperatorSorted, OperatorUnsorted
 export trace, opnorm, eye, dagger, com, add, compress, ptrace, shift_left, shift, com, rotate
 export diag, xcount, ycount, zcount
 export truncate, trim, cutoff, prune, add_noise, k_local_part, participation

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -21,9 +21,9 @@ The first operators of the list On is O
 """
 function lanczos(H::Operator, O::Operator, steps::Int, nterms::Int; keepnorm=true, maxlength=1000, returnOn=false, observer=false)
     @assert typeof(H) == typeof(O)
-    @assert H.N == O.N
+    # @assert H.N == O.N
     @assert observer === false || returnOn === false
-    O0 = deepcopy(O)
+    O0 = copy(O)
     O0 /= norm_lanczos(O0)
     LHO = com(H, O0)
     b = norm_lanczos(LHO)
@@ -39,8 +39,8 @@ function lanczos(H::Operator, O::Operator, steps::Int, nterms::Int; keepnorm=tru
         O2 = trim(O2, nterms; keepnorm=keepnorm)
         returnOn && push!(Ons, O2)
         (observer !== false) && push!(obs, observer(O2))
-        O0 = deepcopy(O1)
-        O1 = deepcopy(O2)
+        O0 = copy(O1)
+        O1 = copy(O2)
         push!(bs, b)
     end
     (observer !== false) && return (bs, obs)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -217,16 +217,10 @@ function com(o1::Operator, o2::Operator; epsilon::Real=0, maxlength::Int=1000, a
             x2 = Base.ctpop_int(w1 & v2)
             k2 = anti ? 1 - ((x2 & 1) << 1) : ((x2 & 1) << 1) - 1
             k = (k1 + k2) % Ts
-            ktest = (-1)^count_ones(v1 & w2) - s * (-1)^count_ones(w1 & v2)
-            @assert k == ktest
 
             c = c1 * o2.coef[j] * k
             if (k != 0) && (abs(c) > epsilon) && pauli_weight(v, w) < maxlength
-                if isassigned(d, (v, w))
-                    d[(v, w)] += c
-                else
-                    insert!(d, (v, w), c)
-                end
+                setwith!(+, d, (v, w), c)
             end
         end
     end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -209,10 +209,10 @@ function com(o1::Operator, o2::Operator; epsilon::Real=0, maxlength::Int=1000, a
             v2, w2 = o2.v[j], o2.w[j]
             v = v1 ⊻ v2
             w = w1 ⊻ w2
-            x1 = count_ones(v1 & w2)
-            k1 = 1 - ((x1 & 1) << 1)
-            x2 = count_ones(w1 & v2)
-            k2 = 1 - ((x2 & 1) << 1)
+            x1 = Base.ctpop_int(v1 & w2)
+            k1 = 1 - signed((x1 & 1) << 1)
+            x2 = Base.ctpop_int(w1 & v2)
+            k2 = 1 - signed((x2 & 1) << 1)
             k = k1 - s * k2
             c = c1 * o2.coef[j] * k
             if (k != 0) && (abs(c) > epsilon) && pauli_weight(v, w) < maxlength

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -202,7 +202,6 @@ function com(o1::Operator, o2::Operator; epsilon::Real=0, maxlength::Int=1000, a
     @assert typeof(o1) == typeof(o2) "Commuting operators of different types"
     o3 = Operator(o1.N)
     d = emptydict(o1)
-            k = (-1)^count_ones(o1.v[i] & o2.w[j]) - s * (-1)^count_ones(o1.w[i] & o2.v[j])
     @inbounds for i in eachindex(o1.v)
         v1, w1 = o1.v[i], o1.w[i]
         c1 = o1.coef[i]
@@ -210,6 +209,11 @@ function com(o1::Operator, o2::Operator; epsilon::Real=0, maxlength::Int=1000, a
             v2, w2 = o2.v[j], o2.w[j]
             v = v1 ⊻ v2
             w = w1 ⊻ w2
+            x1 = count_ones(v1 & w2)
+            k1 = 1 - ((x1 & 1) << 1)
+            x2 = count_ones(w1 & v2)
+            k2 = 1 - ((x2 & 1) << 1)
+            k = k1 - s * k2
             c = c1 * o2.coef[j] * k
             if (k != 0) && (abs(c) > epsilon) && pauli_weight(v, w) < maxlength
                 if isassigned(d, (v, w))

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -202,12 +202,15 @@ function com(o1::Operator, o2::Operator; epsilon::Real=0, maxlength::Int=1000, a
     @assert typeof(o1) == typeof(o2) "Commuting operators of different types"
     o3 = Operator(o1.N)
     d = emptydict(o1)
-    for i in 1:length(o1.v)
-        for j in 1:length(o2.v)
-            v = o1.v[i] ⊻ o2.v[j]
-            w = o1.w[i] ⊻ o2.w[j]
             k = (-1)^count_ones(o1.v[i] & o2.w[j]) - s * (-1)^count_ones(o1.w[i] & o2.v[j])
-            c = o1.coef[i] * o2.coef[j] * k
+    @inbounds for i in eachindex(o1.v)
+        v1, w1 = o1.v[i], o1.w[i]
+        c1 = o1.coef[i]
+        for j in eachindex(o2.v)
+            v2, w2 = o2.v[j], o2.w[j]
+            v = v1 ⊻ v2
+            w = w1 ⊻ w2
+            c = c1 * o2.coef[j] * k
             if (k != 0) && (abs(c) > epsilon) && pauli_weight(v, w) < maxlength
                 if isassigned(d, (v, w))
                     d[(v, w)] += c

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -23,7 +23,7 @@ intialized as : O=Operator(N)
 where N is the number of qubits
 """
 
-
+Base.copy(o::Operator) = deepcopy(o)
 
 function uinttype(o::Operator)
     if typeof(o) == Operator64 || typeof(o) == OperatorTS1D64

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -71,13 +71,14 @@ OperatorTS1D128(N::Int) = OperatorTS1D128(N, UInt128[], UInt128[], Complex{Float
 
 
 function Operator(N::Int, v::Vector{T}, w::Vector{T}, coef::Vector{Complex{Float64}}) where {T<:Unsigned}
-    if N <= 64
-        return Operator64(N, v, w, coef)
-    elseif N <= 128
-        return Operator128(N, v, w, coef)
-    else
-        error("N needs to be <= 128 qubits")
-    end
+    return OperatorUnsorted(N, v, w, coeff)
+    # if N <= 64
+    #     return Operator64(N, v, w, coef)
+    # elseif N <= 128
+    #     return Operator128(N, v, w, coef)
+    # else
+    #     error("N needs to be <= 128 qubits")
+    # end
 end
 
 """
@@ -86,6 +87,7 @@ end
 Initialize an empty operator on N qubits
 """
 function Operator(N::Int)
+    return OperatorUnsorted(N)
     if N <= 64
         return Operator64(N)
     elseif N <= 128

--- a/src/operatorssorted.jl
+++ b/src/operatorssorted.jl
@@ -1,0 +1,335 @@
+# Single Site
+# -----------
+"""
+    @enum[UInt8] PauliBasis I Z X Y
+
+Elementary single-site pauli operators, ordered for easy conversion to and from
+the bit representation: `PauliBasis(v, w) = v + 2w`
+"""
+@enum PauliBasis::UInt8 I = 0b0000 Z = 0b0001 X = 0b0010 Y = 0b0011
+
+function Base.convert(::Type{PauliBasis}, c::Char)
+    return (c == '1' || c == 'I') ? I : c == 'X' ? X : c == 'Y' ? Y : c == 'Z' ? Z :
+           throw(DomainError(c, "PauliBasis must be one of `'1'`, `'I'`, `'X'`, `'Y'`, `'Z'`"))
+end
+
+# @enum ExtendedPauliBasis I X Y Z Sx Sy Sz S⁻ S⁺
+
+# Single String
+# -------------
+"""
+    PauliString{N,B}
+
+Single string of Pauli operators, of length `N` with two bitstrings `v` and `w`.
+"""
+struct PauliString{N,B} <: AbstractVector{PauliBasis}
+    v::B
+    w::B
+end
+PauliString{N}(v::B, w::B) where {N,B} = PauliString{N,B}(v, w)
+
+function storagetype(::Val{N}) where {N}
+    return N < 1 ? throw(DomainError(N, "String length must be strictly positive")) :
+           N ≤ 32 ? UInt32 : N ≤ 64 ? UInt64 : N ≤ 128 ? UInt128 : BitVector
+end
+
+Base.length(::Type{<:PauliString{N}}) where {N} = N
+
+PauliString(x::Union{String,Vector}) = PauliString{length(x)}(x)
+PauliString{N}(x::Union{String,Vector}) where {N} = PauliString{N,storagetype(Val(N))}(x)
+
+# enable syntax p"IXXI"
+macro p_str(x)
+    return PauliString(x)
+end
+
+function Base.show(io::IO, x::PauliString)
+    print(io, "p\"")
+    join(io, x)
+    print(io, "\"")
+end
+function Base.show(io::IO, ::MIME"text/plain", x::PauliString)
+    print(io, "p\"")
+    join(io, x)
+    print(io, "\"")
+end
+
+function PauliString{N,B}(x::Union{String,Vector}) where {N,B}
+    length(x) == N || throw(ArgumentError("Invalid input length"))
+    p = one(PauliString{N,B})
+    @inbounds for i in eachindex(x)
+        p = Base.setindex(p, x[i], i)
+    end
+    return p
+end
+
+Base.sign(p::PauliString) = prod(x -> x == Y ? im : 1, p; init=complex(1))
+
+Base.one(::Type{PauliString{N,B}}) where {N,B} = PauliString{N,B}(zero(B), zero(B))
+
+Base.size(::PauliString{N}) where {N} = (N,)
+
+@inline function Base.getindex(p::PauliString, i::Int)
+    @boundscheck checkbounds(p, i)
+    vi = ((p.v >> (i - 1)) & 1) % UInt8
+    wi = ((p.w >> (i - 2)) & 2) % UInt8
+    return PauliBasis(vi | wi)
+end
+
+@inline function Base.setindex(p::PauliString, b::PauliBasis, i::Int)
+    @boundscheck checkbounds(p, i)
+    v = p.v | ((UInt8(b) & 1) << (i - 1))
+    w = p.w | ((UInt8(b) & 2) << (i - 2))
+    return typeof(p)(v, w)
+end
+@inline Base.setindex(p::PauliString, b::Char, i::Int) = Base.setindex(p, convert(PauliBasis, b), i)
+
+Base.xor(p1::P, p2::P) where {P<:PauliString} = P(p1.v ⊻ p2.v, p1.w ⊻ p2.w)
+Base.:*(p1::P, p2::P) where {P} = p1 ⊻ p2, 1 - ((count_ones(p1.v & p2.w) & 1) << 1)
+Base.isequal(x::P, y::P) where {P<:PauliString} = x.v == y.v && x.w == y.w
+Base.:(==)(x::P, y::P) where {P<:PauliString} = isequal(x, y)
+
+function commutator(p1::P, p2::P) where {P<:PauliString}
+    p = p1 ⊻ p2
+    k = ((count_ones(p2.v & p1.w) & 1) << 1) - ((count_ones(p1.v & p2.w) & 1) << 1)
+    return p, k
+end
+
+function anticommutator(p1::P, p2::P) where {P<:PauliString}
+    p = p1 ⊻ p2
+    k = 2 - (((count_ones(p1.v & p2.w) & 1) << 1) + ((count_ones(p1.w & p2.v) & 1) << 1))
+    return p, k
+end
+
+pauli_weight(p::PauliString) = count_ones(p.v | p.w)
+
+Base.:+(x::P, y::P, z::P...) where {P<:PauliString} = OperatorSorted(collect((x, y, z...)))
+
+# Sum of strings
+# --------------
+"""
+    OperatorSorted
+
+New datastructure for linear combinations of Pauli strings, kept in sorted order.
+"""
+struct OperatorSorted{P<:PauliString,C<:Complex} <: Operator
+    paulistrings::Vector{Pair{P,C}}
+    OperatorSorted{P,C}(x::Vector{Pair{P,C}}) where {P<:PauliString,C<:Complex} = new{P,C}(x)
+end
+
+function OperatorSorted(x::Vector{Pair{P,C}}) where {P<:PauliString,C<:Complex}
+    return OperatorSorted{P,C}(x)
+end
+
+OperatorSorted(x::Vector{P}) where {P<:PauliString} = OperatorSorted{P,Complex{Bool}}(x)
+function OperatorSorted{P,C}(x::Vector{P}) where {P<:PauliString,C<:Number}
+    return OperatorSorted{P,C}(map(p -> (p => one(C)), x))
+end
+
+function Base.show(io::IO, o::OperatorSorted)
+    for (p, c) in o
+        pstr = string(p)
+        cstr = round(c / sign(p), digits=10)
+        println(io, "($cstr) $pstr")
+    end
+end
+
+stringtype(O::OperatorSorted) = stringtype(typeof(O))
+stringtype(::Type{OperatorSorted{P,C}}) where {P,C} = P
+scalartype(O::OperatorSorted) = scalartype(typeof(O))
+scalartype(::Type{OperatorSorted{P,C}}) where {P,C} = C
+
+Base.length(o::OperatorSorted) = length(o.paulistrings)
+Base.zero(o::OperatorSorted) = OperatorSorted(similar(o.paulistrings, 0))
+Base.zero(::Type{OperatorSorted{P,C}}) where {P,C} = OperatorSorted{P,C}(Pair{P,C}[])
+Base.one(o::OperatorSorted) = OperatorSorted([one(stringtype(o)) => one(scalartype(o))])
+
+function Base.similar(::OperatorSorted{P,C}, ::Type{T}) where {P,C,T<:Complex}
+    return zero(OperatorSorted{P,T})
+end
+Base.copy(o::OperatorSorted) = OperatorSorted(copy(o.paulistrings))
+
+function Base.:(==)(o1::OperatorSorted, o2::OperatorSorted)
+    return o1.paulistrings == o2.paulistrings
+end
+function Base.isapprox(o1::OperatorSorted, o2::OperatorSorted; kwargs...)
+    return first.(o1.paulistrings) == first.(o2.paulistrings) && isapprox(last.(o1.paulistrings), last.(o2.paulistrings); kwargs...)
+end
+
+@inline Base.getindex(o::OperatorSorted, i::Int) = o.paulistrings[i]
+@inline function Base.getindex(o::OperatorSorted, p::PauliString)
+    length(p) == length(stringtype(o)) || error()
+    i = searchsortedfirst(o.paulistrings, p; by=first)
+    return i > length(o) ? zero(scalartype(o)) : last(@inbounds o[i])
+end
+
+@inline Base.iterate(o::OperatorSorted, args...) = iterate(o.paulistrings, args...)
+
+function Base.merge!(o::OperatorSorted)
+    m = length(o)
+    m == 0 && return o
+
+    paulistrings = sort!(o.paulistrings; by=first)
+
+    current = processed = 1
+    @inbounds current_str, current_val = paulistrings[current]
+    @inbounds while current < m
+        current += 1
+        next_str, next_val = paulistrings[current]
+        if current_str == next_str
+            current_val = paulistrings[processed].second
+            paulistrings[processed] = current_str => (current_val + next_val)
+        else
+            processed += 1
+            current_str = next_str
+            current_val = next_val
+            if processed < current
+                paulistrings[processed] = current_str => current_val
+            end
+        end
+    end
+    processed < m && resize!(paulistrings, processed)
+
+    return o
+end
+function Base.merge(o1::OperatorSorted, o2::OperatorSorted)
+    paulistrings = merge_sorted(o1.paulistrings, o2.paulistrings; by=first)
+    m = length(paulistrings)
+    current = processed = 1
+    @inbounds current_str, current_val = paulistrings[current]
+    @inbounds while current < m
+        current += 1
+        next_str, next_val = paulistrings[current]
+        if current_str == next_str
+            current_val = paulistrings[processed].second
+            paulistrings[processed] = current_str => (current_val + next_val)
+        else
+            processed += 1
+            current_str = next_str
+            current_val = next_val
+            if processed < current
+                paulistrings[processed] = current_str => current_val
+            end
+        end
+    end
+    processed < m && resize!(paulistrings, processed)
+
+    return OperatorSorted(paulistrings)
+end
+
+function Base.merge!(o::OperatorSorted, os::OperatorSorted...)
+    for o2 in os
+        append!(o.paulistrings, o2.paulistrings)
+    end
+    return merge!(o)
+end
+
+function Base.:+(o1::O, o2::O) where {O<:OperatorSorted}
+    paulistrings = O(vcat(o1.paulistrings, o2.paulistrings))
+    return merge!(paulistrings)
+end
+
+Base.:-(o::OperatorSorted) = -one(scalartype(o)) * o
+Base.:-(o1::O, o2::O) where {O<:OperatorSorted} = o1 + (-o2)
+
+function Base.:*(o::OperatorSorted, λ::Number)
+    return OperatorSorted(map(o.paulistrings) do (str, val)
+        return str => (val * λ)
+    end)
+end
+Base.:*(λ::Number, o::OperatorSorted) = o * λ
+Base.:/(o::OperatorSorted, λ::Number) = o * inv(λ)
+Base.:\(λ::Number, o::OperatorSorted) = o * inv(λ)
+
+const MAX_BUFFER = 2^18
+
+function Base.:*(o1::O, o2::O) where {O<:OperatorSorted}
+    T = Base.promote_op(*, scalartype(o1), scalartype(o2))
+    result = similar(o1, T)
+    buffer = similar(o1, T)
+    for (p1, c1) in o1, (p2, c2) in o2
+        p, k = p1 * p2
+        if k != 0
+            push!(buffer.paulistrings, p => k * c1 * c2)
+            if length(buffer) > MAX_BUFFER
+                # @debug "temporary merge"
+                result = merge(result, merge!(buffer))
+                resize!(buffer.paulistrings, 0)
+            end
+        end
+    end
+    return merge(result, merge!(buffer))
+end
+
+for f in (:commutator, :anticommutator)
+    @eval function $f(o1::O, o2::O; maxlength::Int=1000, epsilon::Real=0) where {O<:OperatorSorted}
+        result = zero(o1)
+        buffer = zero(o1)
+        for (p1, c1) in o1, (p2, c2) in o2
+            p, k = $f(p1, p2)
+            c = k * c1 * c2
+            (k != 0 && pauli_weight(p) < maxlength && abs(c) > epsilon) || continue
+            push!(buffer.paulistrings, p => c)
+            if length(buffer) > MAX_BUFFER
+                # @debug "temporary merge"
+                result = merge(result, merge!(buffer))
+                resize!(buffer.paulistrings, 0)
+            end
+        end
+        return merge(result, merge!(buffer))
+    end
+end
+
+function opnorm(o::OperatorSorted)
+    return norm(last.(o.paulistrings)) / (2.0^(length(stringtype(o)) / 2))
+end
+
+function norm_lanczos(o::OperatorSorted)
+    return norm(last.(o.paulistrings))
+end
+
+function trim(o::OperatorSorted, max_strings::Int; keepnorm::Bool=false, keep::Operator=zero(o))
+    length(o) ≤ max_strings && return copy(o)
+    I = partialsortperm(o.paulistrings, 1:max_strings; by=(abs ∘ last), rev=true)
+
+    @assert length(keep) == 0 "TBA"
+
+    o′ = OperatorSorted(sort!(o.paulistrings[I]; by=first))
+    return keepnorm ? o′ * (opnorm(o) / opnorm(o′)) : o′
+end
+
+# Glue
+# ----
+function com(o1::OperatorSorted, o2::OperatorSorted; anti::Bool=false, kwargs...)
+    return anti ? anticommutator(o1, o2; kwargs...) : commutator(o1, o2; kwargs...)
+end
+OperatorSorted(x::OperatorSorted) = copy(x)
+function OperatorSorted(x::Operator)
+    if length(x) == 0
+        B = eltype(x.v)
+        return OperatorSorted(PauliString{x.N,B}[])
+    else
+        paulistrings = map(x.v, x.w, x.coef) do v, w, c
+            return PauliString{x.N}(v, w) => c
+        end
+        return OperatorSorted(sort!(paulistrings; by=first))
+    end
+end
+
+function merge_sorted(v1, v2; by=identity)
+    isempty(v1) && return copy(v2)
+    isempty(v2) && return copy(v1)
+    v = similar(v1, length(v1) + length(v2))
+    i1 = i2 = 1
+    @inbounds for i in 1:length(v)
+        if i2 > length(v2) || (i1 ≤ length(v1) && by(v1[i1]) ≤ by(v2[i2]))
+            v[i] = v1[i1]
+            i1 += 1
+        else
+            v[i] = v2[i2]
+            i2 += 1
+        end
+    end
+    # @assert i1 == length(v1) && i2 == length(v2)
+    return v
+end

--- a/tmp/profiler.jl
+++ b/tmp/profiler.jl
@@ -1,0 +1,73 @@
+using BenchmarkTools
+using Test
+using PauliStrings
+using Profile
+
+# Lanczos benchmarks
+# ------------------
+# XX hamiltonian: 1d chain with XX + YY interaction
+function XX(N)
+    H = PauliStrings.Operator(N)
+    for j in 1:(N-1)
+        H += "X", j, "X", j + 1
+        H += "Z", j, "Z", j + 1
+    end
+    return H
+end
+
+# X local operator: X operator on each site
+function X(N)
+    H = PauliStrings.Operator(N)
+    for j in 1:N
+        H += "X", j
+    end
+    return H
+end
+
+
+N = 40
+H = XX(N)
+O = X(N)
+Hs = OperatorSorted(H)
+Hu = OperatorUnsorted(H)
+Os = OperatorSorted(O)
+Ou = OperatorUnsorted(O)
+
+steps = 20
+p = 16
+nterms = 2^p
+
+@test OperatorSorted(O * O) == Os * Os
+@test OperatorUnsorted(O * O) == Ou * Ou
+@test OperatorSorted(com(O, O)) == com(Os, Os)
+@test OperatorUnsorted(com(O, O)) == com(Ou, Ou)
+@test OperatorSorted(H * H) == Hs * Hs
+@test OperatorUnsorted(H * H) == Hu * Hu
+@test OperatorSorted(com(H, H)) == com(Hs, Hs)
+@test OperatorUnsorted(com(H, H)) == com(Hu, Hu)
+
+result = PauliStrings.lanczos(H, O, steps, nterms; keepnorm=true)
+
+# Hs = OperatorSorted(H)
+# Os = OperatorSorted(O)
+#
+# result2 = PauliStrings.lanczos(Hs, Os, steps, nterms; keepnorm=true)
+
+Hu = OperatorUnsorted(H)
+Ou = OperatorUnsorted(O)
+
+result3 = PauliStrings.lanczos(Hu, Ou, steps, nterms; keepnorm=true)
+
+@assert !any(isnan, result3)
+
+# b2 = @benchmark PauliStrings.lanczos($Hs, $Os, $steps, $nterms; keepnorm=true)
+# display(b2)
+# b3 = @benchmark PauliStrings.lanczos($Hu, $Ou, $steps, $nterms; keepnorm=true)
+# b1 = @benchmark PauliStrings.lanczos($H, $O, $steps, $nterms; keepnorm=true)
+# display(b1)
+# display(b3)
+
+Profile.clear()
+@bprofile PauliStrings.lanczos($Hu, $Ou, $steps, $nterms; keepnorm=true)
+VSCodeServer.view_profile()
+


### PR DESCRIPTION
Hi Nicolas,

I had some spare time, and was trying to learn some bit-magic and experiment a bit with data structures. (In particular, reading through [this amazing document](https://en.algorithmica.org/), would recommend!)
To get a bit of practice, I figured might as well pick something useful to experiment on, so I played around a bit with the Pauli algebra.

What I really want to do is implement [this datastructure](https://en.algorithmica.org/hpc/data-structures/b-tree/), which I am not actually expecting to speed up this package at all.
However, to make my benchmarks somewhat fair, I first slightly optimized some of the algebra here. If you're interested in taking over some of that code, definitely more than welcome to cherry-pick, it needs a bit of love to actually fit it in the rest but I figured might as well already share.

I added some benchmarks, which you can run via https://github.com/MilesCranmer/AirspeedVelocity.jl:

```bash
benchpkg --rev={DEFAULT},c015ede87fe8,8c67ec8b9caa --output-dir=benchmark/results/ --bench-on=benchstart
```

|                            | main             | c015ede87fe8     | 8c67ec8b9caa     |
|:---------------------------|:----------------:|:----------------:|:----------------:|
| lanczos (N=50)/nterms=2^14 | 0.343 ± 0.0043 s | 0.263 ± 0.0048 s | 0.187 ± 0.038 s  |
| lanczos (N=50)/nterms=2^16 | 0.964 ± 0.0059 s | 0.701 ± 0.049 s  | 0.523 ± 0.019 s  |
| lanczos (N=50)/nterms=2^18 | 2.77 ± 0.017 s   | 1.89 ± 0.0056 s  | 1.4 ± 0.035 s    |
| lanczos (N=50)/nterms=2^20 | 6.07 s           | 3.79 ± 0.049 s   | 2.66 ± 0.019 s   |
| time_to_load               | 0.148 ± 0.0059 s | 0.147 ± 0.0065 s | 0.147 ± 0.0066 s |

---

In case you just want the low-effort optimizations: I checked with a profiler, and the main offender for this difference is this line:
```
k = (-1)^count_ones(o1.v[i] & o2.w[j]) - s * (-1)^count_ones(o1.w[i] & o2.v[j])
```
It seems like the compiler is not smart enough to realize that `(-1)^some_integer_power` simply needs to check the parity of the power, and it implements this by `power_by_squaring`, ie it really computes all the multiplications. This can be avoided by checking the parity with `(x & 1) in (0, 1)`, and then mapping it to desired `(-1, 1)` with `(1 - 2 * (x & 1))`, or in binary magic `(1 - (x & 1) << 2)`. For the commutator, ignoring that I renamed some of the variables this leads to the following:
```
k = ((count_ones(p2.v & p1.w) & 1) << 1) - ((count_ones(p1.v & p2.w) & 1) << 1)
```

---

I also toyed around for a bit with just keeping sorted vectors instead of the dictionaries, but it does seem like merging these is a lot more expensive (although this could presumably be multithreaded more easily Given my preliminary results, I didn't go into that further but the code is still here in case you wanted to play around with that yourself

---

Anyways, I did reorganize some of the code while I was trying things out, so the rest is a bit more of a significant change, but obviously free to adapt as you see fit or ignore ;)
