### PR TITLE
Add benchmark script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /Manifest.toml
 docs/build/
+benchmark/results/
+benchmark/Manifest.toml

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+PauliStrings = "f07625cc-80e4-4099-a362-36a3484d9bcc"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -31,7 +31,7 @@ H = XX(N)
 O = X(N)
 steps = 20
 
-for p in 14:2:20
+for p in 14:2:24
     nterms = 2^p
     g["nterms=2^$p"] = @benchmarkable PauliStrings.lanczos($H, $O, $steps, $nterms; keepnorm=true)
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -31,7 +31,7 @@ H = XX(N)
 O = X(N)
 steps = 20
 
-for p in 14:2:24
+for p in 14:2:20
     nterms = 2^p
     g["nterms=2^$p"] = @benchmarkable PauliStrings.lanczos($H, $O, $steps, $nterms; keepnorm=true)
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,40 @@
+using BenchmarkTools
+using PauliStrings
+
+SUITE = BenchmarkGroup()
+
+# Lanczos benchmarks
+# ------------------
+# XX hamiltonian: 1d chain with XX + YY interaction
+function XX(N)
+    H = PauliStrings.Operator(N)
+    for j in 1:(N-1)
+        H += "X", j, "X", j + 1
+        H += "Z", j, "Z", j + 1
+    end
+    return H
+end
+
+# X local operator: X operator on each site
+function X(N)
+    H = PauliStrings.Operator(N)
+    for j in 1:N
+        H += "X", j
+    end
+    return H
+end
+
+
+N = 50
+g = addgroup!(SUITE, "lanczos (N=$N)")
+H = XX(N)
+O = X(N)
+steps = 20
+
+for p in 14:2:20
+    nterms = 2^p
+    g["nterms=2^$p"] = @benchmarkable PauliStrings.lanczos($H, $O, $steps, $nterms; keepnorm=true)
+end
+
+
+


### PR DESCRIPTION
This is a smaller PR that separates out adding the benchmark script from #22.

It uses the typical `BenchmarkTools.jl` setup, and one way to use this is using [AirSpeedVelocity.jl](https://github.com/MilesCranmer/AirspeedVelocity.jl):
For example, testing the default branch vs the current worktree:

```bash
benchpkg --rev={DEFAULT},dirty --output-dir=benchmark/results/
```

