### PR TITLE
Minor changes for performance improvements

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -118,14 +118,9 @@ function Base.:*(o1::Operator, o2::Operator)
     d = emptydict(o1)
     for i in 1:length(o1.v)
         for j in 1:length(o2.v)
-            v = o1.v[i] ⊻ o2.v[j]
-            w = o1.w[i] ⊻ o2.w[j]
-            c = o1.coef[i] * o2.coef[j] * (-1)^count_ones(o1.v[i] & o2.w[j])
-            if isassigned(d, (v, w))
-                d[(v, w)] += c
-            else
-                insert!(d, (v, w), c)
-            end
+            v, w, k = prod(o1.v[i], o1.w[i], o2.v[j], o2.w[j])
+            c = o1.coef[i] * o2.coef[j] * k
+            setwith!(+, d, (v, w), c)
         end
     end
     return op_from_dict(d, o1.N, typeof(o1))
@@ -239,6 +234,18 @@ function com(v1::Unsigned, w1::Unsigned, v2::Unsigned, w2::Unsigned; anti::Bool=
     end
 
     return k, v, w
+end
+
+"""
+    prod(v1::Unsigned, w1::Unsigned, v2::Unsigned, w2::Unsigned) -> k, v, w
+
+Product of two pauli strings in integer representation
+"""
+function prod(v1::Unsigned, w1::Unsigned, v2::Unsigned, w2::Unsigned)
+    v = v1 ⊻ v2
+    w = w1 ⊻ w2
+    k = 1 - ((count_ones(v1 & w2) & 1) << 1)
+    return v, w, k
 end
 
 

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -197,16 +197,19 @@ function com(o1::Operator, o2::Operator; epsilon::Real=0, maxlength::Int=1000, a
     @assert typeof(o1) == typeof(o2) "Commuting operators of different types"
     o3 = Operator(o1.N)
     d = emptydict(o1)
-    for i in 1:length(o1.v)
-        for j in 1:length(o2.v)
-            k, v, w = com(o1.v[i], o1.w[i], o2.v[j], o2.w[j]; anti)
-            c = o1.coef[i] * o2.coef[j] * k
 
+    @inbounds for i in eachindex(o1.v)
+        v1, w1, c1 = o1.v[i], o1.w[i], o1.coef[i]
+        for j in eachindex(o2.v)
+            v2, w2, c2 = o2.v[j], o2.w[j], o2.coef[j]
+            k, v, w = com(v1, w1, v2, w2; anti)
+            c = c1 * c2 * k
             if (k != 0) && (abs(c) > epsilon) && pauli_weight(v, w) < maxlength
                 setwith!(+, d, (v, w), c)
             end
         end
     end
+
     for (v, w) in keys(d)
         push!(o3.v, v)
         push!(o3.w, w)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -231,9 +231,13 @@ Return k,v,w
 function com(v1::Unsigned, w1::Unsigned, v2::Unsigned, w2::Unsigned; anti::Bool=false)
     v = v1 ⊻ v2
     w = w1 ⊻ w2
-    k1 = (-1)^count_ones(v1 & w2)
-    k2 = (-1)^count_ones(w1 & v2)
-    k = anti ? k1 + k2 : k1 - k2
+
+    if anti
+        k = 2 - (((count_ones(v1 & w2) & 1) << 1) + ((count_ones(w1 & v2) & 1) << 1))
+    else
+        k = ((count_ones(v2 & w1) & 1) << 1) - ((count_ones(v1 & w2) & 1) << 1)
+    end
+
     return k, v, w
 end
 

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -204,9 +204,7 @@ function com(o1::Operator, o2::Operator; epsilon::Real=0, maxlength::Int=1000, a
     d = emptydict(o1)
     for i in 1:length(o1.v)
         for j in 1:length(o2.v)
-            v = o1.v[i] ⊻ o2.v[j]
-            w = o1.w[i] ⊻ o2.w[j]
-            k = (-1)^count_ones(o1.v[i] & o2.w[j]) - s * (-1)^count_ones(o1.w[i] & o2.v[j])
+            k, v, w = com(o1.v[i], o1.w[i], o2.v[j], o2.w[j]; anti)
             c = o1.coef[i] * o2.coef[j] * k
             if (k != 0) && (abs(c) > epsilon) && pauli_weight(v, w) < maxlength
                 if isassigned(d, (v, w))
@@ -233,10 +231,12 @@ end
 Commutator of two pauli strings in integer representation
 Return k,v,w
 """
-function com(v1::Unsigned, w1::Unsigned, v2::Unsigned, w2::Unsigned)
+function com(v1::Unsigned, w1::Unsigned, v2::Unsigned, w2::Unsigned; anti::Bool=false)
     v = v1 ⊻ v2
     w = w1 ⊻ w2
-    k = (-1)^count_ones(v1 & w2) - (-1)^count_ones(w1 & v2)
+    k1 = (-1)^count_ones(v1 & w2)
+    k2 = (-1)^count_ones(w1 & v2)
+    k = anti ? k1 + k2 : k1 - k2
     return k, v, w
 end
 

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -206,12 +206,9 @@ function com(o1::Operator, o2::Operator; epsilon::Real=0, maxlength::Int=1000, a
         for j in 1:length(o2.v)
             k, v, w = com(o1.v[i], o1.w[i], o2.v[j], o2.w[j]; anti)
             c = o1.coef[i] * o2.coef[j] * k
+
             if (k != 0) && (abs(c) > epsilon) && pauli_weight(v, w) < maxlength
-                if isassigned(d, (v, w))
-                    d[(v, w)] += c
-                else
-                    insert!(d, (v, w), c)
-                end
+                setwith!(+, d, (v, w), c)
             end
         end
     end


### PR DESCRIPTION
This PR features some small changes to some of the operations to increase performance while altering the existing code the least amount possible.

On my machine, this leads to: (`bench-on` is needed because benchmark script not yet merged).

```bash
benchpkg --rev={DEFAULT},dirty --bench-on=2a34e3d8e880469dbfddd9dde18ef34b0d4ebf34 --output-dir=benchmark/results/ 
```

```
|                            | main             | dirty            | main/dirty |
|:---------------------------|:----------------:|:----------------:|:----------:|
| lanczos (N=50)/nterms=2^14 | 0.375 ± 0.02 s   | 0.288 ± 0.013 s  | 1.31       |
| lanczos (N=50)/nterms=2^16 | 1.07 ± 0.024 s   | 0.75 ± 0.048 s   | 1.43       |
| lanczos (N=50)/nterms=2^18 | 3.07 ± 0.019 s   | 2.14 ± 0.033 s   | 1.43       |
| lanczos (N=50)/nterms=2^20 | 6.29 s           | 4.24 ± 0.0083 s  | 1.48       |
| time_to_load               | 0.154 ± 0.0062 s | 0.156 ± 0.0086 s | 0.987      |
```