### PR TITLE
Implement qubit-dependent depolarizing noise

### DIFF
--- a/docs/src/docstrings.md
+++ b/docs/src/docstrings.md
@@ -14,6 +14,7 @@ Operator(o::OperatorTS1D)
 ## Truncation and noise
 ```@docs
 add_noise(o::AbstractOperator, g::Real)
+add_noise(o::AbstractOperator, g::AbstractVector{<:Real})
 truncate(o::AbstractOperator, max_lenght::Int; keepnorm::Bool=false)
 k_local_part(o::AbstractOperator, k::Int; atmost=false)
 trim(o::AbstractOperator, max_strings::Int; keepnorm::Bool=false, keep::Operator=Operator(0))

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -111,8 +111,7 @@ coefs, strings = ps.op_to_strings(H)
 `ps.trim(H,N)` keeps the first N trings with higest weight (returns a new Operator)
 `ps.prune(H,alpha)` keeps terms with probability 1-exp(-alpha*abs(c)) (returns a new Operator)
 
-`ps.add_noise(H,g)` adds depolarizing noise that make each strings decay like $e^{gw}$ where $w$ is the length of the string. This is useful when used with `trim` to keep the number of strings manageable during time evolution.
-
+`ps.add_noise(H,g)` adds depolarizing noise that make each strings decay like $e^{gw}$ where $w$ is the length of the string. This is useful when used with `trim` to keep the number of strings manageable during time evolution. If `g` is a vector, it adds local depolarizing noise. For each non-unit Pauli in a string, it decays it by a factor of $e^{g_j}$, so the end result is a string multiplied by `e^{\\sum_j g_j}`, where the sum runs over the sites with non-unit Pauli.
 
 ## Time evolution
 

--- a/src/truncation.jl
+++ b/src/truncation.jl
@@ -210,6 +210,26 @@ function add_noise(o::AbstractOperator, g::Real)
     return o2
 end
 
+"""
+    add_noise(o::Operator, g::AbstractVector{<:Real})
+
+Add local depolarizing noise.
+If `g_j` is the noise amplitude for site `j`, then the string will be multiplied by
+`e^{-\\sum_j g_j}`, where the sum runs over the sites with non-unit Pauli operators. 
+
+"""
+function add_noise(o::AbstractOperator, g::AbstractVector{<:Real})
+    o2 = deepcopy(o)
+    N = qubitlength(o)
+    N != length(g) && throw(ArgumentError("length of g ($(length(g))) must be $N"))
+    for i in 1:length(o)
+        p = o.strings[i]
+        noise_bits = p.v | p.w
+        o2.coeffs[i] *= exp(-sum(Real[g[j] for j in 1:N if ((noise_bits >> (j - 1)) & 1) == 1]))
+    end
+    return o2
+end
+
 
 function participation(o::Operator)
     return sum(o.coeffs .^ 4) / sum(o.coeffs .^ 2)^2

--- a/test/truncation.jl
+++ b/test/truncation.jl
@@ -10,6 +10,10 @@
     @test opnorm(ps.cutoff(O2, 0.5)) <= opnorm(O2)
     @test opnorm(ps.add_noise(O2, 0.5)) < opnorm(O2)
     @test opnorm(ps.add_noise(O2, 0.5)) < opnorm(ps.add_noise(O2, 0.1))
+    g = rand(N)
+    @test opnorm(ps.add_noise(O2, g)) < opnorm(O2)
+    @test opnorm(ps.add_noise(O2, g)) < opnorm(ps.add_noise(O2, 0.2 * g))
+    @test opnorm(Operator(ps.add_noise(O2, fill(0.5, N)) - ps.add_noise(O2, 0.5))) < 1e-10
     @test opnorm(k_local_part(O2, 1) - ps.truncate(O2, 1)) == 0
     O1 = ising1D(N, 0.5)
     O1ts = OperatorTS1D(O1)


### PR DESCRIPTION
This PR closes #34

It includes:

- Implementation of local depolarizing noise using multiple dispatch for ``add_noise``.
- Tests similar to the original  ``add_noise`` with an additional one to verify the constant noise case.
- Updates to the relevant documentation.