### PR TITLE
add dephasing noise

### DIFF
--- a/src/PauliStrings.jl
+++ b/src/PauliStrings.jl
@@ -4,7 +4,7 @@ export AbstractOperator, Operator, OperatorTS1D
 export qubitlength
 export trace, opnorm, eye, dagger, commutator, anticommutator, add, compress, ptrace, shift_left, shift, rotate, com
 export diag, xcount, ycount, zcount
-export truncate, trim, cutoff, prune, add_noise, k_local_part, participation
+export truncate, trim, cutoff, prune, add_noise, add_dephasing_noise, k_local_part, participation
 export rand_local1, rand_local2
 export lanczos, rk4, norm_lanczos, rotate_lower, rk4_lindblad
 export op_to_strings, vw_to_string, string_to_vw, tring_to_dense, op_to_dense, get_pauli, push!, vw_in_o

--- a/src/truncation.jl
+++ b/src/truncation.jl
@@ -215,24 +215,24 @@ end
 
 Apply **local dephasing noise** to an operator expressed in the Pauli‐string basis.
 
-A single‐qubit dephasing channel on qubit \(k\) with rate \(\gamma_k\) acts as
-``\\mathcal{E}_k(P) =
-\\begin{cases}
-P, & P\\in\\{I, Z\\\},\\\\
-e^{-\\gamma_k}\\;P, & P\\in\\{X, Y\\}.
-\\end{cases}``
+A single‐qubit dephasing channel on qubit ``k`` with rate ``\\gamma_k`` acts as
 
-Extending independently to all N qubits, a multi‐qubit Pauli string
+```math
+\\mathcal{E}_k(P) =
+\\begin{cases}
+P, & P \\in \\{I, Z\\}, \\\\
+e^{-\\gamma_k} P, & P \\in \\{X, Y\\}.
+\\end{cases}
+```
+
+Extending independently to all N qubits, a multi-qubit Pauli string
 ``P = \\bigotimes_{k=1}^N P_k,\\quad P_k\\in\\{I,X,Y,Z\\}``, acquires
 the factor
 
-``\\prod_{k=1}^N
-\\begin{cases}
-1, & P_k\\in\\{I,Z\\},\\\\
-e^{-\\gamma_k}, & P_k\in\{X,Y\},
-\\end{cases}
-\\quad\Longrightarrow\quad
-\\exp\\!\\Bigl(-\\sum_{k:P_k\\in\\{X,Y\\}}\\gamma_k\\Bigr)``.
+```math
+\\prod_{k=1}^N \\begin{cases} 1, & P_k\\in\\{I,Z\\},\\\\ e^{-\\gamma_k}, & P_k\\in\\{X,Y\\},
+\\end{cases} \\quad\\Longrightarrow\\quad \\exp\\!\\Bigl(-\\sum_{k:P_k\\in\\{X,Y\\}}\\gamma_k\\Bigr).
+```
 
 ## Example
 

--- a/test/truncation.jl
+++ b/test/truncation.jl
@@ -1,5 +1,38 @@
 
 @testset "truncation" begin
+
+    function ising1D(N, g)
+        H = Operator(N)
+        for j in 1:(N-1)
+            H += "Z", j, "Z", j + 1
+        end
+        H += "Z", 1, "Z", N #periodic boundary condition
+        for j in 1:N
+            H += g, "X", j
+        end
+        return -H
+    end
+
+    function XX(N)
+        H = Operator(N)
+        for j in 1:(N-1)
+            H += ('X', j, 'X', j + 1)
+            H += ('Z', j, 'Z', j + 1)
+        end
+        H += ('X', N, 'X', 1)
+        H += ('Z', N, 'Z', 1)
+        return H
+    end
+
+    """X operator on all sites"""
+    function X(N)
+        H = Operator(N)
+        for j in 1:N
+            H += ('X', j)
+        end
+        return H
+    end
+
     N = 8
     O2 = ps.rand_local2(N)
     @test opnorm(ps.truncate(O2, 1)) == 0
@@ -18,4 +51,48 @@
     @test opnorm(ps.cutoff(O1ts, 0.8)) <= opnorm(O1ts)
     @test opnorm(ps.add_noise(O1ts, 0.5)) < opnorm(O1ts)
     @test opnorm(Operator(ps.add_noise(O1ts, 0.5)) - ps.add_noise(O1, 0.5)) < 1e-10
+    @test opnorm(ps.add_dephasing_noise(O2, zeros(N)) - O2) < 1e-12
+    dephased = ps.add_dephasing_noise(O2, fill(0.5, N))
+    @test opnorm(dephased) < opnorm(O2)
+    op_low = opnorm(ps.add_dephasing_noise(O2, fill(0.1, N)))
+    op_high = opnorm(ps.add_dephasing_noise(O2, fill(1.0, N)))
+    @test op_high < op_low
+    # Test Z-only strings are unaffected
+    O_z = Operator(N)
+    O_z += 1.0, "Z"^N
+    O_z_dephased = ps.add_dephasing_noise(O_z, fill(0.9, N))
+    @test opnorm(O_z_dephased - O_z) < 1e-12
+    I_op = Operator(N)
+    I_op += 1.0, "I"^N
+    I_dephased = ps.add_dephasing_noise(I_op, fill(1.0, N))
+    @test opnorm(I_dephased - I_op) < 1e-12
+    # X-only string should be exponentially damped
+    N = 8
+    O_x = Operator(N)
+    O_x += 1.0, "X"^N
+    O_x_damped = ps.add_dephasing_noise(O_x, fill(1.0, N))
+    coeff = O_x_damped.coeffs[1]
+    expected = exp(-N)
+    @test isapprox(abs(coeff), expected, atol=1e-12)
+    # Random noise vector
+    gammas = rand(N)
+    O_rand = ps.rand_local2(N)
+    O_rand_damped = ps.add_dephasing_noise(O_rand, gammas)
+    @test opnorm(O_rand_damped) < opnorm(O_rand)
+    # Manual check: one coefficient with X and Y should be damped
+    O_test = Operator(3)
+    O_test += 1.0, "XYZ"
+    O_test += 2.0, "ZIZ"
+    g = [0.1, 0.2, 0.3]
+    O_damped = ps.add_dephasing_noise(O_test, g)
+    # locate by PauliString
+    ziz_str = ps.PauliString("ZIZ")
+    xyz_str = ps.PauliString("XYZ")
+    i_ziz = findfirst(==(ziz_str), O_damped.strings)
+    i_xyz = findfirst(==(xyz_str), O_damped.strings)
+    # Z-only term must be exactly unchanged
+    @test isapprox(O_damped.coeffs[i_ziz], 2.0 + 0im, atol=1e-12)
+    # XYZ term must be damped by exp(-g1 - g2)
+    expected = exp(-g[1]) * exp(-g[2])
+    @test isapprox(abs(O_damped.coeffs[i_xyz]), expected, atol=1e-10)
 end


### PR DESCRIPTION
This PR aims to resolve #35! Edit: Added tests as well. During local testing of` truncation.jl, `some tests failed because they rely on the `ising, XX, and X` functions, which are not defined in` PS.jl`. To fix this, I've added these functions to `truncation.jl`, ensuring all tests now pass.

Dephasing noise:

```julia
julia> A = Operator(3);

julia> A += 1.0, "XYZ";

julia> A += 2.0, "ZIZ";

julia> B = add_dephasing_noise(A, [0.1, 0.2, 0.3]);

julia> B.coeffs
2-element Vector{ComplexF64}:
 2.0 + 0.0im
 0.0 + 0.7408182206817178im
```