### PR TITLE
Resolve N>1024 bug 

### DIFF
--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -132,8 +132,9 @@ Periodically shift `x` by `s` bits within periodic windows of length `stride`.
 """
 @inline function _shift(x::Unsigned, s, stride)
     @assert 0 <= s <= stride
+    stride_int = stride
     _, s, stride = unsigned.(promote(x, s, stride))
-    rightzeros = 8 * sizeof(x) % stride
+    rightzeros = 8 * sizeof(x) % stride_int
     rshift = stride - s
 
     # masks for the region that crosses the periodic boundary after the shift


### PR DESCRIPTION
This PR fixes a runtime error that occurs when constructing translation-symmetric operators for large systems (e.g. N = 2048) on Julia 1.12, where PauliStrings uses BitIntegers.UInt2048 for the internal bit representation.

I updated the shift function in translate_symmetry,.jl to use the original stride before promotion, so that the type does not cause an error during the % operation.

This should be a minimally invasive change that bypasses the error and passes all the test cases that originally passed.

<img width="1169" height="549" alt="Screenshot 2026-03-17 at 9 17 13 PM" src="https://github.com/user-attachments/assets/1a0d5496-1939-4bab-b4c4-63c2c9173d5d" />
