### PR TITLE
Add OpenQASM circuit import

### DIFF
--- a/docs/src/circuits.md
+++ b/docs/src/circuits.md
@@ -77,3 +77,37 @@ c.noise_amplitude = 0.05
 p = [real(expect(c, in_state, out_state)) for out_state in out_states]
 bar(out_states, p, legend=false, xlabel="out state", ylabel="<out|U|in>")
 ```
+
+## Loading OpenQASM circuits
+
+Simple OpenQASM 2.0 files can be loaded into the same `Circuit` representation
+with `from_openqasm` or `from_openqasm_file`. The importer supports `qreg`
+declarations and common gates from `qelib1.inc`, including `u1`, `u2`, `u3`,
+controlled gates, and Toffoli gates. Measurements, classical registers, `id`,
+and barriers are ignored because `Circuit` represents the unitary part of the
+circuit.
+
+For example, the following small circuit follows the same layout as many
+[QASMBench](https://github.com/pnnl/QASMBench) examples:
+
+```@example circuits
+qasm = """
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+
+h q[0];
+cx q[0], q[1];
+measure q[0] -> c[0];
+"""
+
+c = from_openqasm(qasm)
+compile(c)
+```
+
+To load from disk:
+
+```julia
+c = from_openqasm_file("bell.qasm")
+```

--- a/src/circuits.jl
+++ b/src/circuits.jl
@@ -9,13 +9,14 @@ export CXGate, CYGate, CZGate, CNOTGate, CPhaseGate
 export MCZGate
 export CSXGate, CSXdgGate
 export Circuit, compile, expect
+export from_openqasm, from_openqasm_file
 export grover_diffusion
 export XGate, YGate, ZGate
 export XXPlusYYGate
 using PauliStrings
 
 single_gates = ["X", "Y", "Z", "H", "RX", "RY", "RZ", "S", "SX", "T", "Tdg", "Phase", "U"]
-two_gates = ["CNOT", "Swap", "CX", "CY", "CZ", "CCX", "CSX", "CSXdg", "XXPlusYY", "CPhase"]
+two_gates = ["CNOT", "Swap", "CX", "CY", "CZ", "CSX", "CSXdg", "XXPlusYY", "CPhase"]
 other = ["CCX", "Noise", "MCZ"]
 
 allowed_gates = vcat(single_gates, two_gates, other)
@@ -77,6 +78,171 @@ function Base.pushfirst!(c::Circuit, gate::String, site_pars::Real...)
     @assert gate in allowed_gates "Unknown gate: $(gate)"
     sites, pars = get_site_pars(gate, site_pars)
     pushfirst!(c.gates, (gate, sites, pars))
+end
+
+
+const OPENQASM_GATE_ALIASES = Dict(
+    "x" => "X",
+    "y" => "Y",
+    "z" => "Z",
+    "h" => "H",
+    "s" => "S",
+    "sx" => "SX",
+    "t" => "T",
+    "tdg" => "Tdg",
+    "sdg" => "Phase",
+    "rx" => "RX",
+    "ry" => "RY",
+    "rz" => "RZ",
+    "u1" => "Phase",
+    "u2" => "U",
+    "p" => "Phase",
+    "phase" => "Phase",
+    "u" => "U",
+    "u3" => "U",
+    "cx" => "CX",
+    "cnot" => "CNOT",
+    "cy" => "CY",
+    "cz" => "CZ",
+    "swap" => "Swap",
+    "ccx" => "CCX",
+    "cp" => "CPhase",
+    "cu1" => "CPhase",
+    "id" => "Id",
+)
+
+
+function _strip_openqasm_comments(src::AbstractString)
+    src = replace(src, r"/\*.*?\*/"s => "")
+    return join(first.(split.(split(src, '\n'), "//")), "\n")
+end
+
+
+function _openqasm_value(expr::AbstractString)
+    expr = strip(expr)
+    if !occursin(r"^[0-9eEpiPI\.\+\-\*\/\(\)\s]+$", expr)
+        error("Unsupported OpenQASM parameter expression: $expr")
+    end
+    expr = replace(lowercase(expr), "pi" => string(pi))
+    parsed = Meta.parse(expr)
+    value = Core.eval(@__MODULE__, parsed)
+    value isa Real || error("OpenQASM parameter is not real-valued: $expr")
+    return value
+end
+
+
+function _openqasm_sites(args::AbstractString, registers)
+    sites = Int[]
+    for arg in split(args, ',')
+        m = match(r"^\s*(\w+)\[(\d+)\]\s*$", arg)
+        m === nothing && error("Unsupported OpenQASM qubit operand: $arg")
+        name = m.captures[1]
+        idx = parse(Int, m.captures[2])
+        haskey(registers, name) || error("Unknown OpenQASM register: $name")
+        offset, len = registers[name]
+        0 <= idx < len || error("Qubit index $idx out of bounds for $name")
+        push!(sites, offset + idx + 1)
+    end
+    return sites
+end
+
+
+"""
+    from_openqasm(src::AbstractString; max_strings=2^30, noise_amplitude=0)
+
+Parse a basic OpenQASM 2.0 circuit into a [`Circuit`](@ref). The parser
+supports `qreg` declarations and common gates from `qelib1.inc`. Measurements,
+classical registers, and barriers are ignored because `Circuit` represents the
+unitary part of a circuit.
+"""
+function from_openqasm(src::AbstractString; max_strings=2^30, noise_amplitude=0)
+    registers = Dict{String,Tuple{Int,Int}}()
+    c = nothing
+    nqubits = 0
+
+    src = _strip_openqasm_comments(src)
+    for raw_statement in split(src, ';')
+        line = strip(raw_statement)
+        isempty(line) && continue
+
+        if startswith(line, "OPENQASM") || startswith(line, "include")
+            continue
+        end
+
+        m = match(r"^qreg\s+(\w+)\[(\d+)\]$", line)
+        if m !== nothing
+            name = m.captures[1]
+            len = parse(Int, m.captures[2])
+            len > 0 || error("Invalid OpenQASM qreg size: $len")
+            !haskey(registers, name) ||
+                error("Duplicate OpenQASM qreg declaration: $name")
+            offset = nqubits
+            registers[name] = (offset, len)
+            nqubits += len
+            if c === nothing
+                c = Circuit(
+                    nqubits;
+                    max_strings=max_strings,
+                    noise_amplitude=noise_amplitude,
+                )
+            else
+                c.N = nqubits
+            end
+            continue
+        end
+
+        if startswith(line, "creg") || startswith(line, "barrier") ||
+           startswith(line, "measure")
+            continue
+        end
+
+        startswith(line, "gate ") &&
+            error("Custom OpenQASM gate definitions are not supported")
+        startswith(line, "opaque ") &&
+            error("Opaque OpenQASM gates are not supported")
+        startswith(line, "if") &&
+            error("Classically controlled OpenQASM gates are not supported")
+
+        c === nothing && error("OpenQASM circuit has no qreg declaration")
+
+        m = match(r"^(\w+)(?:\((.*)\))?\s+(.+)$", line)
+        m === nothing && error("Could not parse OpenQASM statement: $line")
+        qasm_gate, par_src, arg_src = m.captures
+        key = lowercase(qasm_gate)
+        haskey(OPENQASM_GATE_ALIASES, key) ||
+            error("Unsupported OpenQASM gate: $qasm_gate")
+        gate = OPENQASM_GATE_ALIASES[key]
+        sites = _openqasm_sites(arg_src, registers)
+        pars = isnothing(par_src) ? Real[] : Real[
+            _openqasm_value(par) for par in split(par_src, ',')
+        ]
+        if key == "id"
+            isempty(pars) || error("OpenQASM id gate does not take parameters")
+            continue
+        elseif key == "sdg"
+            isempty(pars) || error("OpenQASM sdg gate does not take parameters")
+            push!(c, gate, sites..., -pi / 2)
+            continue
+        elseif key == "u2"
+            length(pars) == 2 || error("OpenQASM u2 gate expects 2 parameters")
+            push!(c, gate, sites..., pi / 2, pars...)
+            continue
+        end
+        push!(c, gate, sites..., pars...)
+    end
+
+    c === nothing && error("OpenQASM circuit has no qreg declaration")
+    return c
+end
+
+
+"""
+    from_openqasm_file(path::AbstractString; kwargs...)
+
+Load a basic OpenQASM 2.0 circuit file into a [`Circuit`](@ref).
+"""
+function from_openqasm_file(path::AbstractString; kwargs...)
+    return from_openqasm(read(path, String); kwargs...)
 end
 
 

--- a/test/circuits.jl
+++ b/test/circuits.jl
@@ -76,5 +76,60 @@ import LinearAlgebra: diag as ldiag
     @test isunitary(RXGate(2, 1, 0.1))
     @test norm(ldiag(op_to_dense(RZGate(2, 1, pi))) - [1im, 1im, -1im, -1im]) < 1e-10
     theta, phi, lam = 0.1, 1.2, 0.3
+    qasm = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg q[3];
+    creg c[3];
+
+    // Bell pair plus a rotation and Toffoli.
+    h q[0];
+    cx q[0], q[1];
+    rz(pi/2) q[1];
+    ccx q[0], q[1], q[2];
+    sdg q[2];
+    u2(pi/4, pi/8) q[0];
+    cu1(pi/3) q[0], q[2];
+    id q[1];
+    barrier q;
+    measure q[0] -> c[0];
+    """
+    c = from_openqasm(qasm)
+    @test c.N == 3
+    @test first.(c.gates) == ["H", "CX", "RZ", "CCX", "Phase", "U", "CPhase"]
+    @test [sites for (_, sites, _) in c.gates] == [[1], [1, 2], [2], [1, 2, 3], [3], [1], [1, 3]]
+    @test c.gates[3][3] == Real[pi / 2]
+    @test c.gates[5][3] == Real[-pi / 2]
+    @test c.gates[6][3] == Real[pi / 2, pi / 4, pi / 8]
+    @test c.gates[7][3] == Real[pi / 3]
+    @test isunitary(compile(c))
+
+    path = tempname() * ".qasm"
+    write(path, qasm)
+    @test from_openqasm_file(path).gates == c.gates
+    rm(path)
+
+    multi_register = from_openqasm("""
+    OPENQASM 2.0;
+    qreg a[1];
+    qreg b[2];
+    x a[0];
+    cx a[0], b[1];
+    """)
+    @test multi_register.N == 3
+    @test [sites for (_, sites, _) in multi_register.gates] == [[1], [1, 3]]
+
+    @test_throws ErrorException from_openqasm("""
+    OPENQASM 2.0;
+    qreg q[1];
+    qreg q[1];
+    """)
+
+    @test_throws ErrorException from_openqasm("""
+    OPENQASM 2.0;
+    qreg q[1];
+    gate custom a { x a; }
+    custom q[0];
+    """)
     @test all(op_to_dense(UGate(1, 1, theta, phi, lam)) .≈ [[cos(theta / 2), exp(1im * phi) * sin(theta / 2)] [-exp(1im * lam) * sin(theta / 2), exp(1im * (phi + lam)) * cos(theta / 2)]])
 end


### PR DESCRIPTION
## Summary
- Adds `from_openqasm` and `from_openqasm_file` for importing basic OpenQASM 2.0 circuits into `PauliStrings.Circuits.Circuit`.
- Supports `qreg` declarations and common `qelib1.inc` gates including single-qubit rotations, phase gates, controlled gates, swaps, and Toffoli gates.
- Documents a QASMBench-style loading example and covers parsing behavior with regression tests.

## Validation
- `julia --project=. test/runtests.jl`
- `julia --project=docs docs/make.jl`
- `git diff --check`

This pull request was prepared with AI assistance, then reviewed and validated locally.

Closes #82