### PR TITLE
Add custom translation periods for PauliStringTS

### DIFF
--- a/src/PauliStrings.jl
+++ b/src/PauliStrings.jl
@@ -2,7 +2,7 @@ module PauliStrings
 
 export AbstractOperator, Operator, OperatorTS, OperatorTS1D, OperatorTS2D
 export PauliStringTS, PauliString
-export qubitlength, paulistringtype, qubitsize, periodicflags
+export qubitlength, paulistringtype, qubitsize, periodicflags, translationperiods
 export trace, eye, dagger, commutator, anticommutator, add, compress, ptrace, shift_left, shift_origin, shift, rotate, com
 export xcount, ycount, zcount
 export xpart, ypart, zpart

--- a/src/evolution.jl
+++ b/src/evolution.jl
@@ -246,10 +246,10 @@ end
 
 function _evolve(method::Trotter, H::Operator{<:PauliStringTS}, O::Operator{<:PauliStringTS}, tspan;
                  truncation, dissipation, fout, hbar)
-    qubitsize(H) == qubitsize(O) && periodicflags(H) == periodicflags(O) ||
-        throw(DimensionMismatch("H and O must share the same translation-symmetry lattice"))
+    _check_translation_symmetry(H, O)
     Ls = qubitsize(O)
     Ps = periodicflags(O)
+    Ks = translationperiods(O)
     n = length(tspan)
     history = _alloc_history(fout, O, n)
     # Evolve the representative as a dense `Operator`: the gates are built from the
@@ -274,9 +274,9 @@ function _evolve(method::Trotter, H::Operator{<:PauliStringTS}, O::Operator{<:Pa
         trotter_step!(Or, g; truncation=truncation)
         Or = dissipation(Or, dt)
         Or = truncation(Or)
-        _save!(history, fout, OperatorTS{Ls,Ps}(Or), i + 1)
+        _save!(history, fout, compress(typeof(O)(paulistringtype(O).(Or.strings), Or.coeffs)), i + 1)
     end
-    return EvolutionResult(collect(tspan), history, OperatorTS{Ls,Ps}(Or))
+    return EvolutionResult(collect(tspan), history, compress(typeof(O)(paulistringtype(O).(Or.strings), Or.coeffs)))
 end
 
 function _evolve(::Trotter, H::AbstractOperator, O::AbstractOperator, tspan;

--- a/src/io.jl
+++ b/src/io.jl
@@ -196,6 +196,7 @@ Base.:-(o::Operator, args::Tuple{Vararg{Any}}) = o + (-1, args...)
 PauliString{N}(args::Vararg{Any}) where {N} = (Operator(N)+args).strings[1]
 PauliStringTS{Ls}(args::Vararg{Any}) where {Ls} = PauliStringTS{Ls,ntuple(i -> true, length(Ls))}(args...)
 PauliStringTS{Ls,Ps}(args::Vararg{Any}) where {Ls,Ps} = PauliStringTS{Ls,Ps}(PauliString{Base.prod(Ls)}(args...))
+PauliStringTS{Ls,Ps,Ks}(args::Vararg{Any}) where {Ls,Ps,Ks} = PauliStringTS{Ls,Ps,Ks}(PauliString{Base.prod(Ls)}(args...))
 
 function Base.:+(o::Operator, term::Tuple{Number,String})
     o1 = deepcopy(o)
@@ -373,7 +374,7 @@ end
 Convert an operator to a dense matrix.
 """
 Base.Matrix(o::Operator) = Matrix(SparseArrays.sparse(o))
-Base.Matrix(o::OperatorTS{Ls,Ps,U,T} where {Ls,Ps,U,T<:Number}) = Matrix(resum(o))
+Base.Matrix(o::Operator{PauliStringTS{Ls,Ps,Ks,U},T} where {Ls,Ps,Ks,U,T<:Number}) = Matrix(resum(o))
 
 """
     get_coeff(o::Operator{P}, p::P) where {P}
@@ -398,7 +399,7 @@ function get_pauli(o::Operator, i::Int)
 end
 
 
-op_to_dense(o::OperatorTS) = op_to_dense(resum(o))
+op_to_dense(o::Operator{<:PauliStringTS}) = op_to_dense(resum(o))
 
 """
     p"paulistring"

--- a/src/lioms.jl
+++ b/src/lioms.jl
@@ -18,7 +18,7 @@ function is_odd_under_spin_flip(op_list::Vector{Int}, time_reversal::Symbol)
 end
 
 """
-    k_local_basis_1d(N::Int, k::Int; translational_symmetry::Bool=false)
+    k_local_basis_1d(N::Int, k::Int; translational_symmetry::Bool=false, translation_period::Integer=1)
 
 Generates the basis of all k-site Pauli strings on N qubits, build from X,Y,Z and identity.
 
@@ -30,7 +30,7 @@ Generates the basis of all k-site Pauli strings on N qubits, build from X,Y,Z an
 # Returns
 - `Vector{<:AbstractOperator}`: Basis of k-site Pauli strings
 """
-function k_local_basis_1d(N::Int, k::Int; translational_symmetry::Bool=false)::Vector{<:AbstractOperator}
+function k_local_basis_1d(N::Int, k::Int; translational_symmetry::Bool=false, translation_period::Integer=1)::Vector{<:AbstractOperator}
     strings = translational_symmetry ? PauliStringTS[] : PauliString[]
 
     @inbounds for i in 1:4^k-1
@@ -47,7 +47,7 @@ function k_local_basis_1d(N::Int, k::Int; translational_symmetry::Bool=false)::V
         string = PauliString{N}(string)
 
         if translational_symmetry
-            push!(strings, PauliStringTS{(N,), (true,)}(string))
+            push!(strings, PauliStringTS{(N,), (true,), (translation_period,)}(string))
         else
             for s in 0:N-1
                 push!(strings, shift(string, s))
@@ -85,7 +85,7 @@ If `time_reversal=:imaginary`, only the latter are included.
 - `Vector{<:AbstractOperator}`: Symmetry-adapted basis of k-site Pauli strings
 """
 function symmetry_adapted_k_local_basis_1d(N::Int, k::Int; time_reversal::Symbol=:imag, spin_flip::Symbol=:even, conserve_magnetization::Symbol=:yes, translational_symmetry::Bool=true)::Vector{<:AbstractOperator}
-    ops = translational_symmetry ? OperatorTS[] : Operator[]
+    ops = AbstractOperator[]
     base_ops = ["1", "S+", "Sz", "S-"]
 
     time_reversal ∈ (:real, :imag) || error("time_reversal must be :real or :imag")
@@ -163,15 +163,15 @@ Follows definitions in [https://arxiv.org/abs/2505.05882](https://arxiv.org/abs/
 - `ops::Vector{AbstractOperator}`: LIOM operators
 """
 function lioms(H::AbstractOperator, support::Vector{T}; threshold::Real=1e-14, f::Function=(H, O) -> im * commutator(H, O))::Tuple{Vector{Float64},Matrix{Float64},Vector{AbstractOperator}} where {T<:AbstractOperator}
-    if isa(H, OperatorTS) && !(T <: OperatorTS || T <: PauliStringTS)
+    if isa(H, Operator{<:PauliStringTS}) && !all(op -> op isa Operator{<:PauliStringTS} || op isa PauliStringTS, support)
         error("If H is an OperatorTS, support operators must also be OperatorTS or PauliStringTS.")
     end
 
     n = length(support)
     support = convert(Vector{Any}, support)
     L = qubitlength(H)
-    num_translations = isa(H, OperatorTS) ? Base.prod(L for (L, p) in zip(qubitsize(H), periodicflags(H)) if p) : 1
-    scale = 1 / (2.0^L * num_translations)
+    ntranslations = isa(H, Operator{<:PauliStringTS}) ? num_translations(qubitsize(H), periodicflags(H), translationperiods(H)) : 1
+    scale = 1 / (2.0^L * ntranslations)
 
     norms = map(op -> norm(op; normalize=true), support)
     @inbounds for i in 1:n
@@ -215,7 +215,7 @@ function lioms(H::AbstractOperator, support::Vector{T}; threshold::Real=1e-14, f
 
     evals, evecs = eigen(Symmetric(Fmat, :U))
     num_to_return = count(<=(threshold), evals)
-    ops = similar(support, num_to_return)
+    ops = Vector{AbstractOperator}(undef, num_to_return)
     @inbounds for i in 1:num_to_return
         ops[i] = cutoff(sum(evecs[:, i] .* support), 1e-10)
     end
@@ -244,7 +244,14 @@ Follows definitions in [https://arxiv.org/abs/2505.05882](https://arxiv.org/abs/
 """
 function lioms(H::T, k::Int; threshold::Real=1e-14, f::Function=(H, O) -> im * commutator(H, O))::Tuple{Vector{Float64},Matrix{Float64},Vector{T}} where {T<:AbstractOperator}
     N = qubitlength(H)
-    ts = isa(H, OperatorTS)
-    support = k_local_basis_1d(N, k; translational_symmetry=ts)
+    ts = isa(H, Operator{<:PauliStringTS})
+    translation_period = if ts
+        Ks = translationperiods(H)
+        length(Ks) == 1 || throw(ArgumentError("lioms(H, k) builds a 1D local basis and requires a 1D OperatorTS Hamiltonian"))
+        only(Ks)
+    else
+        1
+    end
+    support = k_local_basis_1d(N, k; translational_symmetry=ts, translation_period=translation_period)
     return lioms(H, support; threshold=threshold, f=f)
 end

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -44,8 +44,10 @@ end
 
 function trace_product(o1::Operator{<:PauliStringTS}, o2::Operator{<:PauliStringTS}; scale=0)
     checklength(o1, o2)
+    _check_translation_symmetry(o1, o2)
     Ls = qubitsize(o1)
     Ps = periodicflags(o1)
+    Ks = translationperiods(o1)
     tr = zero(scalartype(o1))
 
     # see above
@@ -60,7 +62,7 @@ function trace_product(o1::Operator{<:PauliStringTS}, o2::Operator{<:PauliString
         rep1 = representative(p1)
         p, k = prod(rep1, rep1)
         f = c1 * c2 * k
-        for s in all_shifts(Ls, Ps)
+        for s in all_shifts(Ls, Ps, Ks)
             shifted = shift(rep1, Ls, Ps, s)
             if shifted == rep1
                 tr += f
@@ -69,8 +71,8 @@ function trace_product(o1::Operator{<:PauliStringTS}, o2::Operator{<:PauliString
     end
     (iszero(scale)) && (scale = 2.0^Base.prod(Ls))
     # Calculate the number of translations: product of lengths for periodic dimensions only
-    num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
-    return tr * scale * num_translations
+    ntranslations = num_translations(Ls, Ps, Ks)
+    return tr * scale * ntranslations
 end
 
 Base.@deprecate oppow(o::AbstractOperator, k::Int) o^k
@@ -208,8 +210,10 @@ trace_product(p::PauliString, o::Operator; scale=0) = trace_product(o, p; scale=
 
 function trace_product(o1::Operator{<:PauliStringTS}, o2::PauliStringTS; scale=0)
     checklength(o1, o2)
+    _check_translation_symmetry(o1, o2)
     Ls = qubitsize(o1)
     Ps = periodicflags(o1)
+    Ks = translationperiods(o1)
     tr = zero(scalartype(o1))
     i = findfirst(==(o2), o1.strings)
     isnothing(i) && return tr
@@ -218,15 +222,15 @@ function trace_product(o1::Operator{<:PauliStringTS}, o2::PauliStringTS; scale=0
     c1 = o1.coeffs[i]
     c2 = (1im)^ycount(o2)
     f = c1 * c2 * k
-    for s in all_shifts(Ls, Ps)
+    for s in all_shifts(Ls, Ps, Ks)
         shifted = shift(rep1, Ls, Ps, s)
         if shifted == rep1
             tr += f
         end
     end
     (iszero(scale)) && (scale = 2.0^Base.prod(Ls))
-    num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
-    return tr * scale * num_translations
+    ntranslations = num_translations(Ls, Ps, Ks)
+    return tr * scale * ntranslations
 end
 
 trace_product(p::PauliStringTS, o::Operator{<:PauliStringTS}; scale=0) = trace_product(o, p; scale=scale)
@@ -252,8 +256,21 @@ function trace_product(s1::P, s2::P; scale=0) where {P<:PauliStringTS}
         (scale == 0) && (scale = 2.0^N)
         Ls = qubitsize(s1)
         Ps = periodicflags(s1)
-        num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
-        return scale * num_translations
+        Ks = translationperiods(s1)
+        ntranslations = num_translations(Ls, Ps, Ks)
+        return scale * ntranslations
+    else
+        return 0
+    end
+end
+
+function trace_product(s1::PauliStringTS, s2::PauliStringTS; scale=0)
+    _check_translation_symmetry(s1, s2)
+    rep1 = representative(s1)
+    rep2 = representative(s2)
+    if rep1.v == rep2.v && rep1.w == rep2.w
+        (scale == 0) && (scale = 2.0^qubitlength(s1))
+        return scale * num_translations(qubitsize(s1), periodicflags(s1), translationperiods(s1))
     else
         return 0
     end

--- a/src/operations_strings.jl
+++ b/src/operations_strings.jl
@@ -126,8 +126,10 @@ end
 
 function binary_kernel(op, A::Operator{<:PauliStringTS}, B::PauliStringTS; maxlength=1000, epsilon=1e-16)
     # checklength(A, B)
+    _check_translation_symmetry(A, B)
     Ls = qubitsize(A)
     Ps = periodicflags(A)
+    Ks = translationperiods(A)
 
     d = emptydict(A)
     p1s, c1s = A.strings, A.coeffs
@@ -145,7 +147,7 @@ function binary_kernel(op, A::Operator{<:PauliStringTS}, B::PauliStringTS; maxle
             p, k = op(rep1, shift(rep2, Ls, Ps, s))
             c = c1 * c2 * k
             if (k != 0) && (abs(c) > epsilon) && pauli_weight(p) < maxlength
-                setwith!(+, d, PauliStringTS{Ls,Ps}(p), c)
+                setwith!(+, d, paulistringtype(A)(p), c)
             end
         end
     end
@@ -174,8 +176,10 @@ emptydict(pauli::PauliStringTS) = UnorderedDictionary{typeof(pauli),ComplexF64}(
 
 function binary_kernel(op, A::PauliStringTS, B::PauliStringTS; maxlength=1000, epsilon=1e-16)
     # checklength(A, B)
+    _check_translation_symmetry(A, B)
     Ls = qubitsize(A)
     Ps = periodicflags(A)
+    Ks = translationperiods(A)
     d = emptydict(A)
     p1 = A
     c1 = (1im)^ycount(p1)
@@ -188,7 +192,7 @@ function binary_kernel(op, A::PauliStringTS, B::PauliStringTS; maxlength=1000, e
         p, k = op(rep1, shift(rep2, Ls, Ps, s))
         c = c1 * c2 * k
         if (k != 0) && (abs(c) > epsilon) && pauli_weight(p) < maxlength
-            setwith!(+, d, PauliStringTS{Ls,Ps}(p), c)
+            setwith!(+, d, typeof(A)(p), c)
         end
     end
     o = Operator{typeof(A),ComplexF64}(collect(keys(d)), collect(values(d)))

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -15,6 +15,7 @@ end
 
 defaultperiods(Ls) = ntuple(i -> 1, length(Ls))
 _is_unsigned_type(x) = x isa Type && x <: Unsigned
+_periodicflags(Ls, Ps) = _is_unsigned_type(Ps) ? ntuple(i -> true, length(Ls)) : Ps
 _translationperiods(Ls, Ks) = _is_unsigned_type(Ks) ? defaultperiods(Ls) : Ks
 periodicpaulistringtype(Ls::NTuple{<:Any,Integer}) = (T = uinttype(Base.prod(Ls)); PauliStringTS{Ls,ntuple(i -> true, length(Ls)),T,T})
 periodicpaulistringtype(Ls::NTuple{<:Any,Integer}, Ps::NTuple{<:Any,Bool}) = (T = uinttype(Base.prod(Ls)); PauliStringTS{Ls,Ps,T,T})
@@ -36,7 +37,7 @@ qubitsize(p::PauliStringTS) = qubitsize(typeof(p))
 
 Get the tuple of periodic flags of a given `PauliStringTS`.
 """
-periodicflags(::Type{<:PauliStringTS{Ls,Ps}}) where {Ls,Ps} = Ps
+periodicflags(::Type{<:PauliStringTS{Ls,Ps}}) where {Ls,Ps} = _periodicflags(Ls, Ps)
 periodicflags(p::PauliStringTS) = periodicflags(typeof(p))
 
 """
@@ -125,19 +126,20 @@ function PauliStringTS{Ls,Ps}(p::PauliString) where {Ls,Ps}
 end
 
 function PauliStringTS{Ls,T}(p::PauliString) where {Ls,T<:Unsigned}
-    return PauliStringTS{Ls,ntuple(i -> true, length(Ls)),T,T}(p)
+    return PauliStringTS{Ls,T,T,T}(p)
 end
 
 function PauliStringTS{Ls,Ps,Ks}(p::PauliString) where {Ls,Ps,Ks}
+    flags = _periodicflags(Ls, Ps)
     periods = _translationperiods(Ls, Ks)
-    _validate_translation_symmetry_parameters(Ls, Ps, periods, "PauliStringTS{$Ls,$Ps,$Ks}")
+    _validate_translation_symmetry_parameters(Ls, flags, periods, "PauliStringTS{$Ls,$Ps,$Ks}")
 
     N = qubitlength(p)
     if Base.prod(Ls) != N
         error("Cannot construct PauliStringTS{$Ls,$Ps,$Ks} from PauliString{$N}: $(join(Ls, "×")) != $N.")
     end
 
-    rep = find_representative(p, Ls, Ps, periods)
+    rep = find_representative(p, Ls, flags, periods)
     T = typeof(rep.v)
     if _is_unsigned_type(Ks)
         return PauliStringTS{Ls,Ps,T,T}(rep.v, rep.w)
@@ -146,15 +148,16 @@ function PauliStringTS{Ls,Ps,Ks}(p::PauliString) where {Ls,Ps,Ks}
 end
 
 function PauliStringTS{Ls,Ps,Ks,T}(p::PauliString) where {Ls,Ps,Ks,T<:Unsigned}
+    flags = _periodicflags(Ls, Ps)
     periods = _translationperiods(Ls, Ks)
-    _validate_translation_symmetry_parameters(Ls, Ps, periods, "PauliStringTS{$Ls,$Ps,$Ks,$T}")
+    _validate_translation_symmetry_parameters(Ls, flags, periods, "PauliStringTS{$Ls,$Ps,$Ks,$T}")
 
     N = qubitlength(p)
     if Base.prod(Ls) != N
         error("Cannot construct PauliStringTS{$Ls,$Ps,$Ks,$T} from PauliString{$N}: $(join(Ls, "×")) != $N.")
     end
 
-    rep = find_representative(p, Ls, Ps, periods)
+    rep = find_representative(p, Ls, flags, periods)
     return PauliStringTS{Ls,Ps,Ks,T}(convert(T, rep.v), convert(T, rep.w))
 end
 
@@ -200,7 +203,7 @@ end
     return Iterators.product(map((L, p, K) -> p ? (K:K:L) : (1:1), Ls, Ps, Ks)...)
 end
 @inline all_shifts(::Type{<:PauliStringTS{Ls,Ps,Ks}}) where {Ls,Ps,Ks} =
-    all_shifts(Ls, Ps, _translationperiods(Ls, Ks))
+    all_shifts(Ls, _periodicflags(Ls, Ps), _translationperiods(Ls, Ks))
 
 """
     shift(p::PauliString, Ls::Tuple, shifts::Tuple)
@@ -294,7 +297,7 @@ function OperatorTS{Ls,Ps}(o::Operator) where {Ls,Ps}
 end
 
 function OperatorTS{Ls,T}(o::Operator) where {Ls,T<:Unsigned}
-    return OperatorTS{Ls,ntuple(i -> true, length(Ls)),T}(o)
+    return OperatorTS{Ls,T,T}(o)
 end
 
 function OperatorTS{Ls,Ps,Ks}(o::Operator) where {Ls,Ps,Ks}
@@ -316,7 +319,7 @@ OperatorTS{Ls}(pauli::AbstractString) where {Ls} = OperatorTS{Ls}(PauliString(pa
 qubitsize(::Type{<:Operator{<:PauliStringTS{Ls}}}) where {Ls} = Ls
 qubitsize(op::Operator{<:PauliStringTS}) = qubitsize(typeof(op))
 
-periodicflags(::Type{<:Operator{<:PauliStringTS{Ls,Ps}}}) where {Ls,Ps} = Ps
+periodicflags(::Type{<:Operator{<:PauliStringTS{Ls,Ps}}}) where {Ls,Ps} = _periodicflags(Ls, Ps)
 periodicflags(op::Operator{<:PauliStringTS}) = periodicflags(typeof(op))
 
 translationperiods(::Type{<:Operator{<:PauliStringTS{Ls,Ps,Ks}}}) where {Ls,Ps,Ks} = _translationperiods(Ls, Ks)

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -1,16 +1,24 @@
 """
-    PauliStringTS{Ls, Ps, T<:Unsigned} <: AbstractPauliString
+    PauliStringTS{Ls, Ps, Ks, T<:Unsigned} <: AbstractPauliString
 
 Type representing a translation symmetric sum of a Pauli string. The tuple `Ls` specifies the period in each dimension.
 The tuple `Ps` specifies which dimensions are periodic (true) or open (false). By default all dimensions are periodic.
+The tuple `Ks` specifies the translation period in each dimension. By default all translation periods are 1.
+
+For compatibility, old period-1 type forms use the unsigned storage type as a `Ks` sentinel:
+`PauliStringTS{Ls,Ps,T}` means flags `Ps` with period 1.
 """
-struct PauliStringTS{Ls,Ps,T<:Unsigned} <: AbstractPauliString
+struct PauliStringTS{Ls,Ps,Ks,T<:Unsigned} <: AbstractPauliString
     v::T
     w::T
 end
 
-periodicpaulistringtype(Ls::NTuple{<:Any,Integer}) = PauliStringTS{Ls,ntuple(i -> true, length(Ls)),uinttype(Base.prod(Ls))}
-periodicpaulistringtype(Ls::NTuple{<:Any,Integer}, Ps::NTuple{<:Any,Bool}) = PauliStringTS{Ls,Ps,uinttype(Base.prod(Ls))}
+defaultperiods(Ls) = ntuple(i -> 1, length(Ls))
+_is_unsigned_type(x) = x isa Type && x <: Unsigned
+_translationperiods(Ls, Ks) = _is_unsigned_type(Ks) ? defaultperiods(Ls) : Ks
+periodicpaulistringtype(Ls::NTuple{<:Any,Integer}) = (T = uinttype(Base.prod(Ls)); PauliStringTS{Ls,ntuple(i -> true, length(Ls)),T,T})
+periodicpaulistringtype(Ls::NTuple{<:Any,Integer}, Ps::NTuple{<:Any,Bool}) = (T = uinttype(Base.prod(Ls)); PauliStringTS{Ls,Ps,T,T})
+periodicpaulistringtype(Ls::NTuple{<:Any,Integer}, Ps::NTuple{<:Any,Bool}, Ks::NTuple{<:Any,Integer}) = PauliStringTS{Ls,Ps,Ks,uinttype(Base.prod(Ls))}
 qubitlength(::Type{<:PauliStringTS{Ls}}) where {Ls} = Base.prod(Ls)
 
 """
@@ -30,6 +38,51 @@ Get the tuple of periodic flags of a given `PauliStringTS`.
 """
 periodicflags(::Type{<:PauliStringTS{Ls,Ps}}) where {Ls,Ps} = Ps
 periodicflags(p::PauliStringTS) = periodicflags(typeof(p))
+
+"""
+    translationperiods(::Type{<:PauliStringTS})
+    translationperiods(p::PauliStringTS)
+
+Get the tuple of translation periods of a given `PauliStringTS`.
+"""
+translationperiods(::Type{<:PauliStringTS{Ls,Ps,Ks}}) where {Ls,Ps,Ks} = _translationperiods(Ls, Ks)
+translationperiods(p::PauliStringTS) = translationperiods(typeof(p))
+
+function _validate_translation_symmetry_parameters(Ls, Ps, Ks, name)
+    if !(Ls isa Tuple)
+        error("Cannot construct $name: $Ls is not a Tuple")
+    end
+    if !(Ps isa Tuple)
+        error("Cannot construct $name: $Ps is not a Tuple")
+    end
+    if !(Ks isa Tuple)
+        error("Cannot construct $name: $Ks is not a Tuple")
+    end
+    if length(Ls) != length(Ps) || length(Ls) != length(Ks)
+        error("Cannot construct $name: Ls, Ps, and Ks must have the same length")
+    end
+    for (L, K) in zip(Ls, Ks)
+        if !(K isa Integer) || K < 1
+            error("Cannot construct $name: translation periods must be positive integers")
+        end
+        if L % K != 0
+            error("Cannot construct $name: translation period $K must divide lattice size $L")
+        end
+    end
+end
+
+num_translations(Ls, Ps, Ks) = Base.prod(p ? L ÷ K : 1 for (L, p, K) in zip(Ls, Ps, Ks))
+
+_same_translation_symmetry(a, b) =
+    qubitsize(a) == qubitsize(b) &&
+    periodicflags(a) == periodicflags(b) &&
+    translationperiods(a) == translationperiods(b)
+
+function _check_translation_symmetry(a, b)
+    _same_translation_symmetry(a, b) ||
+        throw(DimensionMismatch("Translation-symmetric operands must share lattice size, periodic flags, and translation periods"))
+    return nothing
+end
 
 for count in [:xcount, :ycount, :zcount, :pauli_weight]
     eval(:($count(p::PauliStringTS) = $count(representative(p))))
@@ -53,7 +106,7 @@ function Base.string(p::PauliStringTS)
     return str(σij)
 end
 
-Base.one(::Type{<:PauliStringTS{Ls,Ps,T}}) where {Ls,Ps,T} = PauliStringTS{Ls,Ps}(one(PauliString{Base.prod(Ls),T}))
+Base.one(::Type{<:PauliStringTS{Ls,Ps,Ks,T}}) where {Ls,Ps,Ks,T} = PauliStringTS{Ls,Ps,Ks}(one(PauliString{Base.prod(Ls),T}))
 Base.isless(a::PauliStringTS, b::PauliStringTS) = isless(representative(a), representative(b))
 
 """
@@ -68,23 +121,41 @@ function PauliStringTS{Ls}(p::PauliString) where {Ls}
 end
 
 function PauliStringTS{Ls,Ps}(p::PauliString) where {Ls,Ps}
-    if !(Ls isa Tuple)
-        error("Cannot construct PauliStringTS{$Ls}: $Ls is not a Tuple")
-    end
-    if !(Ps isa Tuple)
-        error("Cannot construct PauliStringTS{$Ls,$Ps}: $Ps is not a Tuple")
-    end
-    if length(Ls) != length(Ps)
-        error("Cannot construct PauliStringTS{$Ls,$Ps}: Ls and Ps must have the same length")
-    end
+    return PauliStringTS{Ls,Ps,uinttype(Base.prod(Ls))}(p)
+end
+
+function PauliStringTS{Ls,T}(p::PauliString) where {Ls,T<:Unsigned}
+    return PauliStringTS{Ls,ntuple(i -> true, length(Ls)),T,T}(p)
+end
+
+function PauliStringTS{Ls,Ps,Ks}(p::PauliString) where {Ls,Ps,Ks}
+    periods = _translationperiods(Ls, Ks)
+    _validate_translation_symmetry_parameters(Ls, Ps, periods, "PauliStringTS{$Ls,$Ps,$Ks}")
 
     N = qubitlength(p)
     if Base.prod(Ls) != N
-        error("Cannot construct PauliStringTS{$Ls,$Ps} from PauliString{$N}: $(join(Ls, "×")) != $N.")
+        error("Cannot construct PauliStringTS{$Ls,$Ps,$Ks} from PauliString{$N}: $(join(Ls, "×")) != $N.")
     end
 
-    rep = find_representative(p, Ls, Ps)
-    return PauliStringTS{Ls,Ps,typeof(rep.v)}(rep.v, rep.w)
+    rep = find_representative(p, Ls, Ps, periods)
+    T = typeof(rep.v)
+    if _is_unsigned_type(Ks)
+        return PauliStringTS{Ls,Ps,T,T}(rep.v, rep.w)
+    end
+    return PauliStringTS{Ls,Ps,Ks,T}(rep.v, rep.w)
+end
+
+function PauliStringTS{Ls,Ps,Ks,T}(p::PauliString) where {Ls,Ps,Ks,T<:Unsigned}
+    periods = _translationperiods(Ls, Ks)
+    _validate_translation_symmetry_parameters(Ls, Ps, periods, "PauliStringTS{$Ls,$Ps,$Ks,$T}")
+
+    N = qubitlength(p)
+    if Base.prod(Ls) != N
+        error("Cannot construct PauliStringTS{$Ls,$Ps,$Ks,$T} from PauliString{$N}: $(join(Ls, "×")) != $N.")
+    end
+
+    rep = find_representative(p, Ls, Ps, periods)
+    return PauliStringTS{Ls,Ps,Ks,T}(convert(T, rep.v), convert(T, rep.w))
 end
 
 PauliStringTS{Ls}(pauli::AbstractString) where {Ls} = PauliStringTS{Ls}(PauliString(pauli))
@@ -95,19 +166,23 @@ PauliStringTS{Ls}(pauli::AbstractString) where {Ls} = PauliStringTS{Ls}(PauliStr
 
 Returns a unique representative string of the translation symmetric sum of the Pauli string `p`.
 """
-representative(p::PauliStringTS{Ls,Ps,T}) where {Ls,Ps,T} = PauliString{Base.prod(Ls),T}(p.v, p.w)
+representative(p::PauliStringTS{Ls,Ps,Ks,T}) where {Ls,Ps,Ks,T} = PauliString{Base.prod(Ls),T}(p.v, p.w)
 
 @inline function find_representative(p::PauliString, Ls)
     return find_representative(p, Ls, ntuple(i -> true, length(Ls)))
 end
 
 @inline function find_representative(p::PauliString, Ls, Ps)
+    return find_representative(p, Ls, Ps, defaultperiods(Ls))
+end
+
+@inline function find_representative(p::PauliString, Ls, Ps, Ks)
     # It is crucial for performance that this function, along with shift
     # gets inlined so that Ls get constant-propagated eliminating some integer divisions.
     #
     # This broke when using maximum instead of the loop.
     pmax = p
-    for shifts in all_shifts(Ls, Ps)
+    for shifts in all_shifts(Ls, Ps, Ks)
         pshift = shift(p, Ls, Ps, shifts)
         if pshift > pmax
             pmax = pshift
@@ -118,10 +193,14 @@ end
 
 @inline all_shifts(Ls) = all_shifts(Ls, ntuple(i -> true, length(Ls)))
 @inline function all_shifts(Ls, Ps)
-    # For each dimension, if periodic, generate all shifts 1:L, otherwise just 1 (identity)
-    return Iterators.product(map((L, p) -> p ? (1:L) : (1:1), Ls, Ps)...)
+    return all_shifts(Ls, Ps, defaultperiods(Ls))
 end
-@inline all_shifts(::Type{<:PauliStringTS{Ls,Ps}}) where {Ls,Ps} = all_shifts(Ls, Ps)
+@inline function all_shifts(Ls, Ps, Ks)
+    # For each dimension, if periodic, generate all shifts 1:L, otherwise just 1 (identity)
+    return Iterators.product(map((L, p, K) -> p ? (K:K:L) : (1:1), Ls, Ps, Ks)...)
+end
+@inline all_shifts(::Type{<:PauliStringTS{Ls,Ps,Ks}}) where {Ls,Ps,Ks} =
+    all_shifts(Ls, Ps, _translationperiods(Ls, Ks))
 
 """
     shift(p::PauliString, Ls::Tuple, shifts::Tuple)
@@ -189,7 +268,7 @@ Periodically shift `x` by `s` bits within periodic windows of length `stride`.
     return (x << s) & (~(magicmask >> rshift)) | ((x & magicmask) >> rshift)
 end
 
-const OperatorTS{Ls,Ps,U,T} = Operator{PauliStringTS{Ls,Ps,U},T}
+const OperatorTS{Ls,Ps,U,T} = Operator{P,T} where {P<:PauliStringTS{Ls,Ps,U}}
 
 @doc raw"""
     OperatorTS{Ls}(o::Operator)
@@ -211,7 +290,15 @@ function OperatorTS{Ls}(o::Operator) where {Ls}
 end
 
 function OperatorTS{Ls,Ps}(o::Operator) where {Ls,Ps}
-    periodic_strings = PauliStringTS{Ls,Ps}.(o.strings)
+    return OperatorTS{Ls,Ps,uinttype(Base.prod(Ls))}(o)
+end
+
+function OperatorTS{Ls,T}(o::Operator) where {Ls,T<:Unsigned}
+    return OperatorTS{Ls,ntuple(i -> true, length(Ls)),T}(o)
+end
+
+function OperatorTS{Ls,Ps,Ks}(o::Operator) where {Ls,Ps,Ks}
+    periodic_strings = PauliStringTS{Ls,Ps,Ks}.(o.strings)
     coeffs = copy(o.coeffs)
     return compress(Operator{eltype(periodic_strings),eltype(coeffs)}(periodic_strings, coeffs))
 end
@@ -226,18 +313,21 @@ end
 OperatorTS{Ls}(pauli::AbstractString) where {Ls} = OperatorTS{Ls}(PauliString(pauli))
 
 
-qubitsize(::Type{<:OperatorTS{Ls}}) where {Ls} = Ls
+qubitsize(::Type{<:Operator{<:PauliStringTS{Ls}}}) where {Ls} = Ls
 qubitsize(op::Operator{<:PauliStringTS}) = qubitsize(typeof(op))
 
-periodicflags(::Type{<:OperatorTS{Ls,Ps}}) where {Ls,Ps} = Ps
+periodicflags(::Type{<:Operator{<:PauliStringTS{Ls,Ps}}}) where {Ls,Ps} = Ps
 periodicflags(op::Operator{<:PauliStringTS}) = periodicflags(typeof(op))
+
+translationperiods(::Type{<:Operator{<:PauliStringTS{Ls,Ps,Ks}}}) where {Ls,Ps,Ks} = _translationperiods(Ls, Ks)
+translationperiods(op::Operator{<:PauliStringTS}) = translationperiods(typeof(op))
 
 """
     representative(o::OperatorTS)
 
 Returns a unique term of the symmetric sum represented by `o`.
 """
-representative(o::OperatorTS) = Operator(representative.(o.strings), copy(o.coeffs))
+representative(o::Operator{<:PauliStringTS}) = Operator(representative.(o.strings), copy(o.coeffs))
 
 
 """
@@ -245,13 +335,14 @@ representative(o::OperatorTS) = Operator(representative.(o.strings), copy(o.coef
 
 Perform the symmetric sum represented by `o` to yield a dense `Operator` containing unsymmetrized PauliStrings.
 """
-function resum(o::OperatorTS)
+function resum(o::Operator{<:PauliStringTS})
     Ls = qubitsize(o)
     Ps = periodicflags(o)
+    Ks = translationperiods(o)
     rep_op = representative(o)
 
     op = Operator(similar(rep_op.strings, 0), similar(rep_op.coeffs, 0))
-    for s in all_shifts(paulistringtype(o))
+    for s in all_shifts(Ls, Ps, Ks)
         op += shift(rep_op, Ls, Ps, s)
     end
     return op
@@ -259,8 +350,10 @@ end
 
 function binary_kernel(op, A::Operator{<:PauliStringTS}, B::Operator{<:PauliStringTS}; epsilon::Real=0, maxlength::Int=1000)
     checklength(A, B)
+    _check_translation_symmetry(A, B)
     Ls = qubitsize(A)
     Ps = periodicflags(A)
+    Ks = translationperiods(A)
 
     d = emptydict(A)
     p1s, c1s = A.strings, A.coeffs
@@ -279,7 +372,7 @@ function binary_kernel(op, A::Operator{<:PauliStringTS}, B::Operator{<:PauliStri
                 p, k = op(rep1, shift(rep2, Ls, Ps, s))
                 c = c1 * c2 * k
                 if (k != 0) && pauli_weight(p) < maxlength
-                    setwith!(+, d, PauliStringTS{Ls,Ps}(p), c)
+                    setwith!(+, d, paulistringtype(A)(p), c)
                 end
             end
         end
@@ -300,8 +393,9 @@ function trace(o::Operator{<:PauliStringTS})
     # Calculate the number of translations: product of lengths for periodic dimensions only
     Ls = qubitsize(o)
     Ps = periodicflags(o)
-    num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
-    return r * num_translations * 2^qubitlength(o)
+    Ks = translationperiods(o)
+    ntranslations = num_translations(Ls, Ps, Ks)
+    return r * ntranslations * 2^qubitlength(o)
 end
 
 Base.@deprecate opnorm(o::Operator{<:PauliStringTS}) LinearAlgebra.norm(o::Operator{<:PauliStringTS})
@@ -316,8 +410,10 @@ function LinearAlgebra.norm(o::Operator{<:PauliStringTS}; normalize=false)
 end
 
 function LinearAlgebra.norm(p::PauliStringTS; normalize=false)
-    normalize && return sqrt(qubitlength(p))
-    return sqrt(2.0^qubitlength(p) * qubitlength(p))
+    ntranslations = num_translations(qubitsize(p), periodicflags(p), translationperiods(p))
+    n = sqrt(2.0^qubitlength(p) * ntranslations)
+    normalize && return n / (2.0^(qubitlength(p) / 2))
+    return n
 end
 
 
@@ -336,7 +432,10 @@ return true if `o` is translation symmetric on a hypercube with side lengths `Ls
 """
 is_ts(o::Operator, Ls::Tuple) = is_ts(o, Ls, ntuple(i -> true, length(Ls)))
 function is_ts(o::Operator, Ls::Tuple, Ps::Tuple)
-    for s in all_shifts(Ls, Ps)
+    return is_ts(o, Ls, Ps, defaultperiods(Ls))
+end
+function is_ts(o::Operator, Ls::Tuple, Ps::Tuple, Ks::Tuple)
+    for s in all_shifts(Ls, Ps, Ks)
         if norm(o - shift(o, Ls, Ps, s)) / norm(o) > 1.0e-10
             return false
         end
@@ -359,8 +458,10 @@ Base.:+(a::Number, o::Operator{<:PauliStringTS}) = begin
     # Calculate the number of translations: product of lengths for periodic dimensions only
     Ls = qubitsize(o)
     Ps = periodicflags(o)
-    num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
-    OperatorTS{qubitsize(o),periodicflags(o)}(representative(o) + a / num_translations)
+    Ks = translationperiods(o)
+    ntranslations = num_translations(Ls, Ps, Ks)
+    shifted = representative(o) + a / ntranslations
+    compress(typeof(o)(paulistringtype(o).(shifted.strings), shifted.coeffs))
 end
 Base.:+(o::Operator{<:PauliStringTS}, a::Number) = a + o
 
@@ -395,7 +496,7 @@ function OperatorTS2D(op::Operator, L1::Integer; full=true, periodic::NTuple{2,B
     return OperatorTS{(L1, L2),periodic}(op)
 end
 
-OperatorTS2D(op::OperatorTS) = typeof(op)(copy(op.strings), copy(op.coeffs))
+OperatorTS2D(op::Operator{<:PauliStringTS}) = typeof(op)(copy(op.strings), copy(op.coeffs))
 
 
 """

--- a/test/mixed_ts.jl
+++ b/test/mixed_ts.jl
@@ -53,4 +53,66 @@ using LinearAlgebra
     O5 = OperatorTS{Ls,(true, false)}(Operator("X111") + 0.3 * Operator("Z111"))
     @test abs(trace_product(O4, O5) - trace(resum(O4)' * resum(O5))) < 1e-12
 
+    # 4. Test custom translation periods
+    L1 = (6,)
+    Ps1 = (true,)
+    PsOpen1 = (false,)
+    Ks1 = (2,)
+    p1 = PauliString("X11111")
+    pts_period2 = PauliStringTS{L1,Ps1,Ks1}(p1)
+    pts_period2_shift = PauliStringTS{L1,Ps1,Ks1}(shift(p1, L1, Ps1, (2,)))
+    pts_period2_other_orbit = PauliStringTS{L1,Ps1,Ks1}(shift(p1, L1, Ps1, (1,)))
+
+    @test pts_period2 == pts_period2_shift
+    @test pts_period2 != pts_period2_other_orbit
+    @test translationperiods(pts_period2) == Ks1
+    @test length(resum(OperatorTS(pts_period2))) == 3
+    @test trace_product(pts_period2, pts_period2) ≈ 2.0^qubitlength(pts_period2) * 3
+    @test norm(pts_period2) ≈ sqrt(2.0^qubitlength(pts_period2) * 3)
+    @test norm(pts_period2; normalize=true) ≈ sqrt(3)
+    pts_period2_u16 = PauliStringTS{L1,Ps1,Ks1}(PauliString{6,UInt16}("X11111"))
+    @test trace_product(pts_period2, pts_period2_u16) ≈ trace_product(pts_period2, pts_period2)
+
+    @test PauliStringTS{L1,(true,),UInt8}(p1) == PauliStringTS{L1}(p1)
+    @test PauliStringTS{L1,PsOpen1,UInt8}(p1) == PauliStringTS{L1,PsOpen1}(p1)
+    @test PauliStringTS{L1,UInt8}(p1) == PauliStringTS{L1}(p1)
+    @test PauliStringTS{L1,UInt16}(PauliString{6,UInt16}("X11111")) isa PauliStringTS{L1,Ps1,UInt16,UInt16}
+    @test PauliStringTS{L1}(p1) isa PauliStringTS{L1,(true,),UInt8}
+    @test PauliStringTS{L1,PsOpen1}(p1) isa PauliStringTS{L1,PsOpen1,UInt8}
+    @test pts_period2 isa PauliStringTS{L1,Ps1,Ks1,UInt8}
+    @test_throws ErrorException PauliStringTS{L1,Ps1,(4,)}(p1)
+
+    O6 = OperatorTS{L1,Ps1,Ks1}(Operator("X11111") + 0.25 * Operator("Y11111"))
+    O7 = OperatorTS{L1,Ps1,Ks1}(Operator("Z11111") + 0.5 * Operator("X11111"))
+    old_string_dispatch(::PauliStringTS{L1,(true,),UInt8}) = :old_string_default_flags
+    old_string_dispatch(::PauliStringTS{L1,PsOpen1,UInt8}) = :old_string_with_flags
+    old_operator_dispatch(::OperatorTS{L1,Ps1,UInt8,T}) where {T} = :old_operator_with_flags
+    @test old_string_dispatch(PauliStringTS{L1}(p1)) == :old_string_default_flags
+    @test old_string_dispatch(PauliStringTS{L1,PsOpen1}(p1)) == :old_string_with_flags
+    @test old_string_dispatch(PauliStringTS{L1,UInt8}(p1)) == :old_string_default_flags
+    @test OperatorTS{L1,UInt8}(Operator("X11111")) isa OperatorTS{L1,Ps1,UInt8,ComplexF64}
+    @test old_operator_dispatch(OperatorTS{L1,Ps1}(Operator("X11111"))) == :old_operator_with_flags
+    @test old_operator_dispatch(OperatorTS{L1,UInt8}(Operator("X11111"))) == :old_operator_with_flags
+    @test O6 isa OperatorTS{L1,Ps1,Ks1}
+    @test translationperiods(O6) == Ks1
+    @test length(resum(O6)) == 6
+    @test is_ts(resum(O6), L1, Ps1, Ks1)
+    @test !is_ts(Operator("X11111"), L1, Ps1, Ks1)
+    @test norm(resum(O6 * O7) - resum(O6) * resum(O7)) < 1e-12
+    @test abs(trace_product(O6, O7) - trace(resum(O6)' * resum(O7))) < 1e-12
+
+    support_period2 = k_local_basis_1d(6, 1; translational_symmetry=true, translation_period=2)
+    @test all(translationperiods.(support_period2) .== Ref(Ks1))
+
+    Ks2 = (3,)
+    pts_period3 = PauliStringTS{L1,Ps1,Ks2}(p1)
+    O8 = OperatorTS{L1,Ps1,Ks2}(Operator("X11111"))
+    @test_throws DimensionMismatch O6 * O8
+    @test_throws DimensionMismatch O6 * pts_period3
+    @test_throws DimensionMismatch pts_period2 * pts_period3
+    @test_throws DimensionMismatch trace_product(O6, O8)
+    @test_throws DimensionMismatch trace_product(O6, pts_period3)
+    @test_throws DimensionMismatch trace_product(pts_period2, pts_period3)
+    @test_throws DimensionMismatch evolve(O6, O8, 0.01, 1; method=Trotter(), fout=identity)
+
 end

--- a/test/mixed_ts.jl
+++ b/test/mixed_ts.jl
@@ -73,10 +73,11 @@ using LinearAlgebra
     pts_period2_u16 = PauliStringTS{L1,Ps1,Ks1}(PauliString{6,UInt16}("X11111"))
     @test trace_product(pts_period2, pts_period2_u16) ≈ trace_product(pts_period2, pts_period2)
 
-    @test PauliStringTS{L1,(true,),UInt8}(p1) == PauliStringTS{L1}(p1)
+    @test representative(PauliStringTS{L1,(true,),UInt8}(p1)) == representative(PauliStringTS{L1}(p1))
     @test PauliStringTS{L1,PsOpen1,UInt8}(p1) == PauliStringTS{L1,PsOpen1}(p1)
-    @test PauliStringTS{L1,UInt8}(p1) == PauliStringTS{L1}(p1)
-    @test PauliStringTS{L1,UInt16}(PauliString{6,UInt16}("X11111")) isa PauliStringTS{L1,Ps1,UInt16,UInt16}
+    @test representative(PauliStringTS{L1,UInt8}(p1)) == representative(PauliStringTS{L1}(p1))
+    @test PauliStringTS{L1,UInt8}(p1) isa PauliStringTS{L1,UInt8}
+    @test PauliStringTS{L1,UInt16}(PauliString{6,UInt16}("X11111")) isa PauliStringTS{L1,UInt16}
     @test PauliStringTS{L1}(p1) isa PauliStringTS{L1,(true,),UInt8}
     @test PauliStringTS{L1,PsOpen1}(p1) isa PauliStringTS{L1,PsOpen1,UInt8}
     @test pts_period2 isa PauliStringTS{L1,Ps1,Ks1,UInt8}
@@ -84,15 +85,21 @@ using LinearAlgebra
 
     O6 = OperatorTS{L1,Ps1,Ks1}(Operator("X11111") + 0.25 * Operator("Y11111"))
     O7 = OperatorTS{L1,Ps1,Ks1}(Operator("Z11111") + 0.5 * Operator("X11111"))
+    legacy_string_dispatch(::PauliStringTS{L1,UInt8}) = :legacy_string_default_flags
     old_string_dispatch(::PauliStringTS{L1,(true,),UInt8}) = :old_string_default_flags
     old_string_dispatch(::PauliStringTS{L1,PsOpen1,UInt8}) = :old_string_with_flags
+    legacy_operator_dispatch(::OperatorTS{L1,UInt8}) = :legacy_operator_default_flags
     old_operator_dispatch(::OperatorTS{L1,Ps1,UInt8,T}) where {T} = :old_operator_with_flags
+    @test legacy_string_dispatch(PauliStringTS{L1,UInt8}(p1)) == :legacy_string_default_flags
     @test old_string_dispatch(PauliStringTS{L1}(p1)) == :old_string_default_flags
     @test old_string_dispatch(PauliStringTS{L1,PsOpen1}(p1)) == :old_string_with_flags
-    @test old_string_dispatch(PauliStringTS{L1,UInt8}(p1)) == :old_string_default_flags
-    @test OperatorTS{L1,UInt8}(Operator("X11111")) isa OperatorTS{L1,Ps1,UInt8,ComplexF64}
+    @test periodicflags(PauliStringTS{L1,UInt8}(p1)) == Ps1
+    @test translationperiods(PauliStringTS{L1,UInt8}(p1)) == (1,)
+    @test OperatorTS{L1,UInt8}(Operator("X11111")) isa OperatorTS{L1,UInt8}
+    @test legacy_operator_dispatch(OperatorTS{L1,UInt8}(Operator("X11111"))) == :legacy_operator_default_flags
     @test old_operator_dispatch(OperatorTS{L1,Ps1}(Operator("X11111"))) == :old_operator_with_flags
-    @test old_operator_dispatch(OperatorTS{L1,UInt8}(Operator("X11111"))) == :old_operator_with_flags
+    @test periodicflags(OperatorTS{L1,UInt8}(Operator("X11111"))) == Ps1
+    @test translationperiods(OperatorTS{L1,UInt8}(Operator("X11111"))) == (1,)
     @test O6 isa OperatorTS{L1,Ps1,Ks1}
     @test translationperiods(O6) == Ks1
     @test length(resum(O6)) == 6


### PR DESCRIPTION
Closes nicolasloizeau/PauliStrings.jl#75.

## Summary

This adds support for custom translation periods in the translation-symmetric Pauli string representation:

- generalizes `PauliStringTS` so period `k` is part of the type-level symmetry metadata
- preserves compatibility for existing one-site translation-symmetric constructors and call sites
- preserves legacy unsigned-type forms like `PauliStringTS{Ls,T}` and `OperatorTS{Ls,T}`
- updates operations, IO, moments, LIOM helpers, and evolution paths that inspect or construct `PauliStringTS`
- adds mixed-period tests that compare the translation-symmetric representation against the naive `Operator` representation

## Validation

Ran locally on Windows with Julia 1.12.6:

```text
julia --project=. -e "using Pkg; Pkg.test()"
```

Result:

```text
Testing PauliStrings tests passed
```

The new `mixed ts` regression coverage includes the legacy `PauliStringTS{Ls,T}` and `OperatorTS{Ls,T}` forms required by the issue's compatibility clause.

## UnitHACK / AI Disclosure

This PR is for the unitaryHACK 2026 bounty on issue #75.

I used OpenAI Codex to help inspect the issue, draft and refine the compatibility implementation, and review edge cases around the `PauliStringTS` / `OperatorTS` type parameters. I manually reviewed the changes and verified them locally with the full package test suite before submission.
