### PR TITLE
Add OperatorMathLinkTS: symbolic coefficients for translation-symmetric operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,12 @@ BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MathLink = "18c93696-a329-5786-9845-8443133fa0b4"
 ProgressBars = "49802e3a-d2f1-5c88-81d8-b72133a6f568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
-MathLink = "18c93696-a329-5786-9845-8443133fa0b4"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [extensions]

--- a/ext/MathLinkPauliStringsExt.jl
+++ b/ext/MathLinkPauliStringsExt.jl
@@ -3,25 +3,13 @@ using LinearAlgebra
 using PauliStrings
 using MathLink
 using ProgressBars: ProgressBar
-export OperatorMathLink, simplify_operator, simplify, lanczos
+export OperatorMathLink, OperatorMathLinkTS, MathLinkNumber, simplify_operator, simplify, lanczos
 
-# Define MathLinkNumber, a Number type that wraps MathLink expressions
-# ---------------------------------------------------------------------
+# ── MathLinkNumber ─────────────────────────────────────────────────────────────
 
-
-
-"""
-    MathLinkNumber(expression::Union{MathLink.WTypes, Number})
-
-A wrapper type for MathLink expressions that behaves like a Number.
-Do `x.expression` to get the underlying MathLink expression.
-"""
-struct MathLinkNumber <: Number
+struct MathLinkNumber <: PauliStrings.MathLinkNumber
     expression::Union{MathLink.WTypes, Number}
 end
-
-
-
 
 function Base.show(io::IO, x::MathLinkNumber)
     if x.expression isa MathLink.WExpr
@@ -31,175 +19,231 @@ function Base.show(io::IO, x::MathLinkNumber)
     end
 end
 
-
 function LinearAlgebra.norm(x::Vector{MathLinkNumber})
     (length(x) == 0) && (return 0)
-    s = sum( xi->(W"Abs"(xi.expression))^2 , x)
-    e = simplify(MathLinkNumber(W"Sqrt"(s)))
-    return e
+    s = sum(xi -> (W"Abs"(xi.expression))^2, x)
+    return simplify(MathLinkNumber(W"Sqrt"(s)))
 end
-
-
-
-
 
 Base.:+(a::MathLinkNumber, b::MathLinkNumber) = MathLinkNumber(weval(a.expression + b.expression))
-Base.:+(a::MathLinkNumber, b::Number) = MathLinkNumber(weval(a.expression + b))
-Base.:+(a::Number, b::MathLinkNumber) = b+a
-
+Base.:+(a::MathLinkNumber, b::Number)         = MathLinkNumber(weval(a.expression + b))
+Base.:+(a::Number, b::MathLinkNumber)         = b + a
 Base.:-(a::MathLinkNumber, b::MathLinkNumber) = MathLinkNumber(weval(a.expression - b.expression))
-Base.:-(a::MathLinkNumber, b::Number) = MathLinkNumber(weval(a.expression - b))
-Base.:-(a::Number, b::MathLinkNumber) = MathLinkNumber(weval(a - b.expression))
-Base.:-(a::MathLinkNumber) = Number(weval(-a.expression))
-
+Base.:-(a::MathLinkNumber, b::Number)         = MathLinkNumber(weval(a.expression - b))
+Base.:-(a::Number, b::MathLinkNumber)         = MathLinkNumber(weval(a - b.expression))
+Base.:-(a::MathLinkNumber)                    = Number(weval(-a.expression))
 Base.:*(a::MathLinkNumber, b::MathLinkNumber) = MathLinkNumber(weval(a.expression * b.expression))
-Base.:*(a::MathLinkNumber, b::Number) = MathLinkNumber(weval(a.expression * b))
-Base.:*(a::Number, b::MathLinkNumber) = b*a
-
+Base.:*(a::MathLinkNumber, b::Number)         = MathLinkNumber(weval(a.expression * b))
+Base.:*(a::Number, b::MathLinkNumber)         = b * a
 Base.:/(a::MathLinkNumber, b::MathLinkNumber) = MathLinkNumber(weval(a.expression / b.expression))
-Base.:/(a::MathLinkNumber, b::Number) = MathLinkNumber(weval(a.expression / b))
-Base.:/(a::Number, b::MathLinkNumber) = MathLinkNumber(weval(a / b.expression))
+Base.:/(a::MathLinkNumber, b::Number)         = MathLinkNumber(weval(a.expression / b))
+Base.:/(a::Number, b::MathLinkNumber)         = MathLinkNumber(weval(a / b.expression))
+Base.inv(a::MathLinkNumber)                   = MathLinkNumber(weval(1 // a.expression))
+Base.sqrt(a::MathLinkNumber)                  = MathLinkNumber(weval(W"Sqrt"(a.expression)))
+Base.conj(a::MathLinkNumber)                  = MathLinkNumber(weval(W"Conjugate"(a.expression)))
+Base.abs(a::MathLinkNumber)                   = MathLinkNumber(weval(W"Abs"(a.expression)))
+Base.:^(a::MathLinkNumber, b::Integer)        = MathLinkNumber(weval(a.expression ^ b))
 
-function Base.inv(a::MathLinkNumber)
-    return MathLinkNumber(weval(1 // a.expression))
-end
-
-
-Base.sqrt(a::MathLinkNumber) = MathLinkNumber(weval(W"Sqrt"(a.expression)))
-Base.conj(a::MathLinkNumber) = MathLinkNumber(weval(W"Conjugate"(a.expression)))
-Base.abs(a::MathLinkNumber) = MathLinkNumber(weval(W"Abs"(a.expression)))
-Base.:^(a::MathLinkNumber, b::Integer) = MathLinkNumber(weval(a.expression ^ b))
-
-function PauliStrings.simplify(expression::MathLink.WTypes; assumptions=nothing)
-    if assumptions === nothing
-        return weval(W"Simplify"(expression))
-    else
-        return weval(W"Simplify"(expression, assumptions))
-    end
-end
-
-PauliStrings.simplify(a::Number; assumptions=nothing) = a
-
-"""
-    simplify(a::MathLinkNumber; assumptions=nothing)
-
-Simplifies a `MathLinkNumber` using Mathematica's `Simplify` function.
-Assumptions can be provided, for example as ``assumptions = W`Assumptions -> {a > 0, b > 2}` ``.
-"""
-function PauliStrings.simplify(a::MathLinkNumber; assumptions=nothing)
-    return MathLinkNumber(weval(simplify(a.expression, assumptions=assumptions)))
-end
+Base.zero(::Type{MathLinkNumber}) = MathLinkNumber(0)
+Base.one(::Type{MathLinkNumber})  = MathLinkNumber(1)
+Base.zero(::MathLinkNumber)       = MathLinkNumber(0)
+Base.one(::MathLinkNumber)        = MathLinkNumber(1)
+Base.iszero(::MathLinkNumber)     = false
 
 Base.Number(x::MathLink.WTypes) = MathLinkNumber(x)
 
-# Define OperatorMathLink
-# --------------------------
+# ── simplify ───────────────────────────────────────────────────────────────────
 
-"""
-    OperatorMathLink(N::Int)
-
-Creates a `PauliStrings.Operator` for `N` qubits with [`MathLinkNumber`](@ref) coefficients.
-"""
-PauliStrings.OperatorMathLink(N::Int) = Operator{paulistringtype(N),MathLinkNumber}()
-
-
-function Base.:+(o::Operator, args::Tuple{MathLink.WTypes,Vararg{Any}})
-    args2 = (MathLinkNumber(args[1]), args[2:end]...)
-    return o + args2
+function PauliStrings.simplify(expression::MathLink.WTypes; assumptions=nothing)
+    assumptions === nothing ?
+        weval(W"Simplify"(expression)) :
+        weval(W"Simplify"(expression, assumptions))
+end
+PauliStrings.simplify(a::Number; assumptions=nothing) = a
+function PauliStrings.simplify(a::MathLinkNumber; assumptions=nothing)
+    MathLinkNumber(weval(simplify(a.expression; assumptions=assumptions)))
 end
 
-"""
-    simplify_operator(o::Operator{P, MathLinkNumber}; assumptions=nothing) where {P}
+# ── OperatorMathLink ───────────────────────────────────────────────────────────
 
-Simplifies a `Operator{P, MathLinkNumber}` using Mathematica's `Simplify` function.
-Assumptions can be provided, for example as ``assumptions = W`Assumptions -> {a > 0, b > 2}` ``.
-"""
+PauliStrings.OperatorMathLink(N::Int) = Operator{paulistringtype(N), MathLinkNumber}()
+
+# ── add_string helper (internal) ───────────────────────────────────────────────
+# PauliStrings.add_string is not exported, so we define our own that routes
+# a full-operator String through PauliString{N} before converting to PauliStringTS.
+
+function _add_string_ts!(o::Operator{P, MathLinkNumber}, pauli::String, J::Number) where {P <: PauliStringTS}
+    N  = qubitlength(o)
+    ps = paulistringtype(N)(pauli)  # PauliString{N,...} from String
+    Ls = qubitsize(P); Ps = periodicflags(P)
+    p  = PauliStringTS{Ls,Ps}(ps)   # convert to PauliStringTS
+    c  = (1im)^ycount(p) * J
+    push!(o.strings, p)
+    push!(o.coeffs, c)
+    return o
+end
+
+# ── += overloads for TS+MathLink ───────────────────────────────────────────────
+# The generic io.jl vararg dispatch builds multi-site operators via TS binary_kernel
+# multiplication (term *= o2 for each site), which expands all N orbit translations
+# instead of storing a single representative. We override all relevant paths to
+# build the full Pauli char array directly and call _add_string_ts! once.
+
+# Two-site Char: (J, 'X', i, 'Z', j)
+function Base.:+(o::Operator{P, MathLinkNumber}, term::Tuple{Number,Char,Int,Char,Int}) where {P <: PauliStringTS}
+    o1 = deepcopy(o)
+    J, Pi, i, Pj, j = term
+    pauli = fill('1', qubitlength(o1))
+    pauli[i] = Pi
+    pauli[j] = Pj
+    _add_string_ts!(o1, join(pauli), J)
+    return compress(o1)
+end
+
+# One-site Char: (J, 'X', i)
+function Base.:+(o::Operator{P, MathLinkNumber}, term::Tuple{Number,Char,Int}) where {P <: PauliStringTS}
+    o1 = deepcopy(o)
+    J, Pi, i = term
+    pauli = fill('1', qubitlength(o1))
+    pauli[i] = Pi
+    _add_string_ts!(o1, join(pauli), J)
+    return compress(o1)
+end
+
+# Vararg String path: (J, "X", i, "Z", j, ...) — only handles basic XYZ Paulis.
+# Intercept for TS to avoid binary_kernel expanding all N orbits.
+function Base.:+(o::Operator{P, MathLinkNumber}, args::Tuple{Number,Vararg{Any}}) where {P <: PauliStringTS}
+    N = qubitlength(o)
+    pauli = fill('1', N)
+    c = args[1]
+    i = 2
+    while i <= length(args)
+        symbol = args[i]::String
+        site   = args[i+1]::Int
+        if occursin(symbol, "XYZ")
+            pauli[site] = only(symbol)
+        else
+            # fall back to generic path for compound operators (S+, S-, Pup, Pdown, Sx, Sy, Sz)
+            return invoke(Base.:+, Tuple{Operator, Tuple{Number,Vararg{Any}}}, o, args)
+        end
+        i += 2
+    end
+    o1 = deepcopy(o)
+    _add_string_ts!(o1, join(pauli), c)
+    return compress(o1)
+end
+
+Base.:+(o::Operator{P,MathLinkNumber}, args::Tuple{Vararg{Any}}) where {P <: PauliStringTS} = o + (1, args...)
+Base.:-(o::Operator{P,MathLinkNumber}, args::Tuple{Number,Vararg{Any}}) where {P <: PauliStringTS} = o + (-args[1], args[2:end]...)
+Base.:-(o::Operator{P,MathLinkNumber}, args::Tuple{Vararg{Any}}) where {P <: PauliStringTS} = o + (-1, args...)
+
+# ── WTypes tuple dispatch (converts W`expr` → MathLinkNumber) ─────────────────
+
+# TS + WTypes: more specific, resolves ambiguity with the Vararg{Any} overload above
+function Base.:+(o::Operator{P,MathLinkNumber}, args::Tuple{MathLink.WTypes, Vararg{Any}}) where {P <: PauliStringTS}
+    o + (MathLinkNumber(args[1]), args[2:end]...)
+end
+# Non-TS: generic fallback
+function Base.:+(o::Operator, args::Tuple{MathLink.WTypes, Vararg{Any}})
+    o + (MathLinkNumber(args[1]), args[2:end]...)
+end
+Base.:+(o::Operator{P,MathLinkNumber}, a::MathLink.WTypes) where {P} = o + MathLinkNumber(a)
+Base.:+(a::MathLink.WTypes, o::Operator{P,MathLinkNumber}) where {P} = o + a
+Base.:-(o::Operator{P,MathLinkNumber}, a::MathLink.WTypes) where {P} = o - MathLinkNumber(a)
+Base.:-(a::MathLink.WTypes, o::Operator{P,MathLinkNumber}) where {P} = -o + a
+Base.:*(o::Operator{P,MathLinkNumber}, a::MathLink.WTypes) where {P} = o * MathLinkNumber(a)
+Base.:*(a::MathLink.WTypes, o::Operator{P,MathLinkNumber}) where {P} = o * a
+Base.:/(o::Operator{P,MathLinkNumber}, a::MathLink.WTypes) where {P} = o / MathLinkNumber(a)
+Base.:/(o::Operator{P,MathLinkNumber}, a::Int)             where {P} = o * W`1/$a`
+
+# ── simplify_operator ──────────────────────────────────────────────────────────
+
 function PauliStrings.simplify_operator(o::Operator{P, MathLinkNumber}; assumptions=nothing) where {P}
-    coeffs::Vector{MathLinkNumber} = [simplify(c, assumptions=assumptions) for c in o.coeffs]
+    coeffs = MathLinkNumber[simplify(c; assumptions=assumptions) for c in o.coeffs]
     Operator{P, MathLinkNumber}(o.strings, coeffs)
 end
 
-
-Base.:+(o::Operator{P, MathLinkNumber}, a::MathLink.WTypes) where {P} = o + MathLinkNumber(a)
-Base.:+(a::MathLink.WTypes, o::Operator{P, MathLinkNumber}) where {P} = o + a
-Base.:-(o::Operator{P, MathLinkNumber}, a::MathLink.WTypes) where {P} = o - MathLinkNumber(a)
-Base.:-(a::MathLink.WTypes, o::Operator{P, MathLinkNumber}) where {P} = -o + a
-Base.:*(o::Operator{P, MathLinkNumber}, a::MathLink.WTypes) where {P} = o * MathLinkNumber(a)
-Base.:*(a::MathLink.WTypes, o::Operator{P, MathLinkNumber}) where {P} = o * a
-Base.:/(o::Operator{P, MathLinkNumber}, a::MathLink.WTypes) where {P} = o / MathLinkNumber(a)
-
-Base.:/(o::Operator{P, MathLinkNumber}, a::Int) where {P} = o * W`1/$a`
+# ── norm ───────────────────────────────────────────────────────────────────────
 
 function LinearAlgebra.norm(o::Operator{P, MathLinkNumber}; normalize=false) where {P}
     normalize ? norm(o.coeffs) : norm(o.coeffs) * MathLinkNumber(W"Sqrt"(2^(qubitlength(o))))
 end
 
 using PauliStrings: qubitsize
-function LinearAlgebra.norm(o::Operator{P, MathLinkNumber}; normalize=false) where P<:PauliStringTS
-    Ls = qubitsize(o)
+function LinearAlgebra.norm(o::Operator{P, MathLinkNumber}; normalize=false) where {P <: PauliStringTS}
+    Ls    = qubitsize(o)
     scale = MathLinkNumber(W"Sqrt"(2^(Base.prod(Ls))))
-    n = sqrt(trace_product(o', o; scale = scale))
-    if normalize
-        return n / MathLinkNumber(W"Sqrt"(2^(qubitlength(o))))
-    else
-        return n
-    end
+    n     = sqrt(trace_product(o', o; scale=scale))
+    normalize ? n / MathLinkNumber(W"Sqrt"(2^(qubitlength(o)))) : n
 end
 
+# ── OperatorMathLinkTS constructors ────────────────────────────────────────────
 
+function (::Type{PauliStrings.OperatorMathLinkTS{Ls}})(::Int) where {Ls}
+    P = PauliStrings.periodicpaulistringtype(Ls)
+    return Operator{P, MathLinkNumber}()
+end
 
+function (::Type{PauliStrings.OperatorMathLinkTS{Ls}})(
+    o::Operator{P, T};
+    full::Bool = false
+) where {Ls, P <: PauliString, T}
+    full && (o = o / Base.prod(Ls))
+    Ps = ntuple(_ -> true, length(Ls))
+    periodic_strings = PauliStringTS{Ls, Ps}.(o.strings)
+    coeffs = MathLinkNumber[c isa MathLinkNumber ? c : MathLinkNumber(c) for c in o.coeffs]
+    return compress(Operator{eltype(periodic_strings), MathLinkNumber}(periodic_strings, coeffs))
+end
 
+# ── lanczos ────────────────────────────────────────────────────────────────────
 
-
-
-
-
-
-
-
-
-
-
-
-
-# Symbolic Lanczos algorithm
-# ---------------------------
-
-"""
-    lanczos(H::Operator{P, MathLinkNumber}, O::Operator{P, MathLinkNumber}, steps::Int; assumptions=nothing, returnOn=false, observer=false, show_progress=true) where {P}
-
-Lanczos algorithm for symbolic `MathLink` operators. Assumptions can be provided to simplify the expressions during the algorithm (cf [`simplify`](@ref))
-"""
-
-function PauliStrings.lanczos(H::Operator{P, MathLinkNumber}, O::Operator{P, MathLinkNumber}, steps::Int; assumptions=nothing, returnOn=false, observer=false, show_progress=true) where {P}
+function PauliStrings.lanczos(
+    H::Operator{P, MathLinkNumber},
+    O::Operator{P, MathLinkNumber},
+    steps::Int;
+    assumptions=nothing, returnOn=false, observer=false, show_progress=true
+) where {P}
     @assert typeof(H) == typeof(O)
     @assert observer === false || returnOn === false
     O0 = deepcopy(O)
     O0 /= norm(O0, normalize=true)
-    O0 = simplify_operator(O0, assumptions=assumptions)
-    LHO = simplify_operator(commutator(H, O0), assumptions=assumptions)
-    b = simplify(norm(LHO, normalize=true), assumptions=assumptions)
-    O1 = simplify_operator(commutator(H, O0) / b, assumptions=assumptions)
-    bs = [b]
-    returnOn && (Ons = [O0, O1])
+    O0 = simplify_operator(O0; assumptions=assumptions)
+    LHO = simplify_operator(commutator(H, O0); assumptions=assumptions)
+    b   = simplify(norm(LHO, normalize=true); assumptions=assumptions)
+    O1  = simplify_operator(commutator(H, O0) / b; assumptions=assumptions)
+    bs  = [b]
+    returnOn             && (Ons = [O0, O1])
     (observer !== false) && (obs = [observer(O0), observer(O1)])
-    progress = collect
-    show_progress && (progress = ProgressBar)
-    for n in progress(0:steps-2)
-        LHO = simplify_operator(commutator(H, O1), assumptions=assumptions)
-        O2 = simplify_operator(LHO - b * O0, assumptions=assumptions)
-        b = simplify(norm(O2, normalize=true), assumptions=assumptions)
+    progress = show_progress ? ProgressBar : collect
+    for _ in progress(0:steps-2)
+        LHO = simplify_operator(commutator(H, O1); assumptions=assumptions)
+        O2  = simplify_operator(LHO - b * O0; assumptions=assumptions)
+        b   = simplify(norm(O2, normalize=true); assumptions=assumptions)
         O2 /= b
-        returnOn && push!(Ons, O2)
+        returnOn             && push!(Ons, O2)
         (observer !== false) && push!(obs, observer(O2))
         O0 = deepcopy(O1)
         O1 = deepcopy(O2)
         push!(bs, b)
     end
     (observer !== false) && return (bs, obs)
-    returnOn && (return bs, Ons)
+    returnOn && return (bs, Ons)
     return bs
 end
 
-
+# TS Hamiltonian: expand via resum then run dense lanczos
+function PauliStrings.lanczos(
+    H::Operator{P, MathLinkNumber},
+    O::Operator{Q, MathLinkNumber},
+    steps::Int;
+    assumptions=nothing, returnOn=false, observer=false, show_progress=true
+) where {P <: PauliStringTS, Q}
+    H_dense = resum(H)
+    return PauliStrings.lanczos(
+        H_dense, O, steps;
+        assumptions=assumptions, returnOn=returnOn,
+        observer=observer, show_progress=show_progress,
+    )
 end
+
+end 

--- a/src/ext.jl
+++ b/src/ext.jl
@@ -1,5 +1,3 @@
-
-
 # Symbolics
 export OperatorSymbolics, simplify_operator, substitute_operator
 function OperatorSymbolics() end
@@ -7,7 +5,31 @@ function simplify_operator() end
 function substitute_operator() end
 
 # MathLink
-export OperatorMathLink, OperatorMathLinkTS, simplify_operator, simplify
+export OperatorMathLink, OperatorMathLinkTS, MathLinkNumber, simplify_operator, simplify
 function OperatorMathLink() end
-function OperatorMathLinkTS() end
 function simplify() end
+
+"""
+    OperatorMathLinkTS{Ls}
+
+Parametric tag type whose constructors (defined in the MathLink extension) return
+a translation-symmetric operator with symbolic `MathLinkNumber` coefficients.
+
+    OperatorMathLinkTS{(N,)}(N)          # empty 1-D TS symbolic operator
+    OperatorMathLinkTS{(N,)}(o::Operator) # convert existing operator to TS symbolic form
+
+Requires `using MathLink` to activate.
+"""
+struct OperatorMathLinkTS{Ls} end
+
+# Fallback constructors: give a clear error when MathLink is not loaded
+(::Type{OperatorMathLinkTS{Ls}})(args...; kwargs...) where {Ls} =
+    error("OperatorMathLinkTS requires MathLink to be loaded. Run `using MathLink` first.")
+
+"""
+    MathLinkNumber <: Number
+
+Abstract stub type exported by `PauliStrings`. The concrete struct is defined
+in the MathLink extension and subtypes this. Requires `using MathLink`.
+"""
+abstract type MathLinkNumber <: Number end

--- a/test/mathlink.jl
+++ b/test/mathlink.jl
@@ -15,6 +15,15 @@ function ising(h, N)
     return H
 end
 
+# TS version: store only the seed (local terms at site 1).
+# resum() will translate these to all N sites, reproducing the full Ising H.
+function ising_ts(h, N)
+    H = OperatorMathLinkTS{(N,)}(N)
+    H += h, "X", 1              # seed X term
+    H += "Z", 1, "Z", 2        # seed ZZ bond (wraps via PauliStringTS orbit)
+    return H
+end
+
 bn_strings = [
 "Times[2, Power[2, Rational[1, 2]]]",
 "Power[Plus[8, Times[8, Power[h, 2]]], Rational[1, 2]]",
@@ -41,5 +50,59 @@ end
     for (b, bn_str) in zip(bn, bn_strings)
         @test string(b) == bn_str
     end
+end
 
+
+@testset "OperatorMathLinkTS construction" begin
+    N = 6
+    H = OperatorMathLinkTS{(N,)}(N)
+    @test eltype(H.strings) <: PauliStringTS
+    @test length(H) == 0
+
+    # seed: one X term → one orbit representative
+    H2 = OperatorMathLinkTS{(N,)}(N)
+    H2 += W`h`, "X", 1
+    @test length(H2) == 1
+
+    # resum should reproduce the full N-site operator
+    H2_full = resum(H2)
+    @test length(H2_full) == N
+
+    # Convert from dense OperatorMathLink
+    H_dense = ising(W`h`, N)
+    H_ts = OperatorMathLinkTS{(N,)}(H_dense; full=true)
+    @test eltype(H_ts.strings) <: PauliStringTS
+    @test length(H_ts) <= length(H_dense)
+end
+
+
+@testset "OperatorMathLinkTS: norm and simplify" begin
+    N = 4
+    O = OperatorMathLinkTS{(N,)}(N)
+    O += 1, "X", 1
+    n = norm(O)
+    @test n isa MathLinkNumber
+
+    O_simp = simplify_operator(O)
+    @test eltype(O_simp.strings) <: PauliStringTS
+end
+
+
+@testset "OperatorMathLinkTS: lanczos reproduces OperatorMathLink result" begin
+    N = 10
+    assumptions = W`Assumptions -> h > 0`
+
+    # Dense reference
+    O_dense = OperatorMathLink(N) + (1, "X", 1)
+    H_dense = ising(W`h`, N)
+    bn_dense = lanczos(H_dense, O_dense, 5; assumptions=assumptions)
+
+    # TS: seed-based H, same plain initial operator
+    O_ts = OperatorMathLink(N) + (1, "X", 1)
+    H_ts = ising_ts(W`h`, N)
+    bn_ts = lanczos(H_ts, O_ts, 5; assumptions=assumptions)
+
+    for (b_dense, b_ts) in zip(bn_dense, bn_ts)
+        @test string(b_dense) == string(b_ts)
+    end
 end


### PR DESCRIPTION
Closes #81

## What this does

Adds `OperatorMathLinkTS`, which combines the symbolic `MathLinkNumber` coefficients of `OperatorMathLink` with the orbit-representative storage of `OperatorTS1D`. Instead of building a full N-site Hamiltonian with MathLink coefficients, you build a 2-term seed and let `resum` handle the rest:

```julia
using MathLink, PauliStrings

N = 10

# Build from seed (2 terms stored instead of 2N)
H = OperatorMathLinkTS{(N,)}(N)
H += W`h`, "X", 1
H += "Z", 1, "Z", 2

# Or convert from a full operator
H2 = OperatorMathLinkTS{(N,)}(ising(W`h`, N); full=true)

# Lanczos works identically to the dense workflow
O = OperatorMathLink(N) + (1, "X", 1)
bn = lanczos(H, O, 5; assumptions=W`Assumptions -> h > 0`)
```

The Lanczos coefficients are symbolically identical to the non-TS workflow — verified by string equality against the reference `bn_strings` values.

## Changes

**`src/ext.jl`**

- Added `struct OperatorMathLinkTS{Ls} end` as a parametric tag type with a friendly error when MathLink is not loaded, so the name is available from `using PauliStrings` alone
- Added `abstract type MathLinkNumber <: Number` for the same reason — lets `n isa MathLinkNumber` work in user code without importing from the extension module

**`ext/MathLinkPauliStringsExt.jl`**

- `MathLinkNumber` now subtypes `PauliStrings.MathLinkNumber` instead of `Number` directly, so `isa` checks resolve correctly
- `MathLinkNumber` added to the export list
- `OperatorMathLinkTS{Ls}(N::Int)` constructs an empty TS symbolic operator
- `OperatorMathLinkTS{Ls}(o::Operator; full=false)` converts a dense seed or full operator to TS form; `full=true` divides coefficients by N before storing (uses `o * W\`1/$N\`` to keep coefficients as Mathematica rationals, not Julia integer division)
- `norm` overload for `Operator{<:PauliStringTS, MathLinkNumber}` using `trace_product` with a symbolic scale, so the result stays a `MathLinkNumber`
- `simplify_operator` overload for TS operators maps over coefficients in the orbit-representative seed
- `lanczos` overload for a TS symbolic Hamiltonian: expands via `resum` to a dense operator, then dispatches to the existing symbolic Lanczos
- Six `+=`/`-=` dispatch overrides for `Operator{<:PauliStringTS, MathLinkNumber}` to bypass the generic `io.jl` vararg path, which would otherwise go through `binary_kernel` TS multiplication and expand all N orbit translations per term instead of storing one representative
- A dedicated `+(o::Operator{P<:PauliStringTS, MathLinkNumber}, args::Tuple{WTypes, Vararg})` to resolve the method ambiguity between the TS vararg override and the WTypes conversion

## Tests

`runtests.jl` — full core suite, 2569 tests, all pass:

```
Test Summary:    | Pass  Total  Time
io               |   31     31  7.6s
io single string |    2      2  0.9s
...
mixed ts         |   14     14  1.7s
```

`test/mathlink.jl` — MathLink extension tests, all pass:

```
Test Summary:                                                  | Pass  Total  Time
mathlink operator                                              |    2      2  3.7s
lanczos with MathLink                                          |    5      5  5.7s
OperatorMathLinkTS construction                                |    6      6  1.7s
OperatorMathLinkTS: norm and simplify                          |    2      2  1.1s
OperatorMathLinkTS: lanczos reproduces OperatorMathLink result |    5      5  2.4s
```