### PR TITLE
Implement translation-symmetric trotterization (issue #78)

### DIFF
--- a/src/evolution.jl
+++ b/src/evolution.jl
@@ -248,35 +248,29 @@ function _evolve(method::Trotter, H::Operator{<:PauliStringTS}, O::Operator{<:Pa
                  truncation, dissipation, fout, hbar)
     qubitsize(H) == qubitsize(O) && periodicflags(H) == periodicflags(O) ||
         throw(DimensionMismatch("H and O must share the same translation-symmetry lattice"))
-    Ls = qubitsize(O)
-    Ps = periodicflags(O)
     n = length(tspan)
     history = _alloc_history(fout, O, n)
-    # Evolve the representative as a dense `Operator`: the gates are built from the
-    # resummed (translation-unfolded) `H`, so applying them to the representative term
-    # reproduces the translation-symmetric dynamics. `representative` returns a fresh
-    # `Operator`, so `trotter_step!`'s in-place mutation never aliases the caller's `O`.
-    Or = representative(O)
-    Hr = resum(H)
+    # Copy to avoid aliasing the caller's O
+    O = copy(O)
 
-    # Cache gates when the save spacing is uniform; rebuild per step otherwise.
+    # Build gates from representative terms only — M gates instead of N×M
     dt0 = n > 1 ? (tspan[2] - tspan[1]) : zero(eltype(tspan))
     uniform = n > 1 && all(i -> tspan[i + 1] - tspan[i] ≈ dt0, 1:(n - 1))
     gates_cached = method.gates !== nothing ? method.gates :
                    (uniform && n > 1 ?
-                    trotterize(Hr, dt0; order=method.order, heisenberg=true, hbar=hbar) :
+                    trotterize(H, dt0; order=method.order, heisenberg=true, hbar=hbar) :
                     nothing)
 
     for i in ProgressBar(1:(n - 1))
         dt = tspan[i + 1] - tspan[i]
         g = gates_cached !== nothing ? gates_cached :
-            trotterize(Hr, dt; order=method.order, heisenberg=true, hbar=hbar)
-        trotter_step!(Or, g; truncation=truncation)
-        Or = dissipation(Or, dt)
-        Or = truncation(Or)
-        _save!(history, fout, OperatorTS{Ls,Ps}(Or), i + 1)
+            trotterize(H, dt; order=method.order, heisenberg=true, hbar=hbar)
+        trotter_step!(O, g; truncation=truncation)
+        O = dissipation(O, dt)
+        O = truncation(O)
+        _save!(history, fout, O, i + 1)
     end
-    return EvolutionResult(collect(tspan), history, OperatorTS{Ls,Ps}(Or))
+    return EvolutionResult(collect(tspan), history, O)
 end
 
 function _evolve(::Trotter, H::AbstractOperator, O::AbstractOperator, tspan;

--- a/src/trotter.jl
+++ b/src/trotter.jl
@@ -49,7 +49,7 @@ Build a first-order (`order=1`, Lie) or second-order (`order=2`, Strang) Trotter
 `exp(im * H * dt / hbar)` (Heisenberg) or the conjugate sequence (Schrödinger / density matrix).
 Each gate uses [`pauli_rotation`](@ref) with the returned `theta` field.
 
-For `H::Operator{<:PauliStringTS}`, see the specialized [`trotterize`](@ref) that calls [`resum`](@ref) first.
+For `H::Operator{<:PauliStringTS}`, see the specialized [`trotterize`](@ref) that builds gates from representative terms only.
 """
 function trotterize(H::Operator, dt::Real; order::Integer=2, heisenberg::Bool=true, hbar::Real=1)
     order ∈ (1, 2) || throw(ArgumentError("order must be 1 or 2, got $order"))
@@ -105,5 +105,97 @@ function trotter_step!(O::Operator, gates::AbstractVector{<:TrotterGate}; trunca
         append!(O.strings, O2.strings)
         append!(O.coeffs, O2.coeffs)
     end
+    return O
+end
+
+# ──────────────────────────────────────────────────
+# Translation-symmetric Trotter
+# ──────────────────────────────────────────────────
+
+"""
+    trotterize(H::Operator{<:PauliStringTS}, dt::Real; order=2, heisenberg=true, hbar=1)
+
+Build a Trotter gate list from the **representative** (unit-cell) terms of the
+translation-symmetric Hamiltonian `H`. This produces `M` gates (order 1) or
+`2M-1` gates (order 2) instead of `N×M`, where `M = length(H)` is the number
+of unique representative terms and `N` is the number of translation shifts.
+
+The returned gates have plain `PauliString` generators (the representatives).
+Pass them to the [`trotter_step!`](@ref) method for `OperatorTS`, which
+internally applies every translation of each gate.
+"""
+function trotterize(H::Operator{<:PauliStringTS}, dt::Real; order::Integer=2, heisenberg::Bool=true, hbar::Real=1)
+    order ∈ (1, 2) || throw(ArgumentError("order must be 1 or 2, got $order"))
+    Hr = representative(H)
+    n = qubitlength(H)
+    norm(Hr - Hr') > 1e-10 && throw(ArgumentError("Hamiltonian must be Hermitian for Trotter splitting"))
+    if length(Hr) == 0
+        return TrotterGate{paulistringtype(n),Float64}[]
+    end
+    if order == 1 || length(Hr) == 1
+        return _lie_gates(Hr, dt, hbar, heisenberg)
+    else
+        return _strang_gates(Hr, dt, hbar, heisenberg)
+    end
+end
+
+
+"""
+    trotter_step!(O::Operator{<:PauliStringTS}, gates::AbstractVector{<:TrotterGate}; truncation, truncate_every)
+
+Apply one Trotter step to a translation-symmetric operator **in place**.
+`gates` should come from [`trotterize`](@ref) on an `OperatorTS` — they contain
+only the representative generators. This method internally applies every
+translation of each gate and re-symmetrizes the result.
+"""
+function trotter_step!(O::Operator{<:PauliStringTS}, gates::AbstractVector{<:TrotterGate};
+                       truncation::Function=identity, truncate_every::Int=1)
+    isempty(gates) && return O
+    Ls = qubitsize(O)
+    Ps = periodicflags(O)
+
+    # Unwrap to representative (plain Operator with PauliString entries)
+    Or = representative(O)
+    d = emptydict(Or)
+
+    gate_count = 0
+    # U = V1*V2*...*VL => conjugation applies VL,...,V1 (reverse)
+    for g in Iterators.reverse(gates)
+        G_rep = g.generator
+        stheta, ctheta = sincos(g.theta)
+
+        # Apply every translation of this representative gate sequentially
+        for s in all_shifts(Ls, Ps)
+            gate_count += 1
+            G = shift(G_rep, Ls, Ps, s)
+            phase = (1.0im)^ycount(G)
+
+            empty!(d)
+            for (P, c) in zip(Or.strings, Or.coeffs)
+                C, k = commutator(G, P)
+                setwith!(+, d, P, c)
+                if k != 0
+                    setwith!(+, d, P, c * ctheta - c)
+                    setwith!(+, d, C, c * (1im * stheta / 2) * phase * k)
+                end
+            end
+
+            ks = Vector{keytype(d)}(undef, length(d))
+            vs = Vector{valtype(d)}(undef, length(d))
+            for (j, (k, v)) in enumerate(pairs(d))
+                @inbounds ks[j] = k
+                @inbounds vs[j] = v
+            end
+            Or = Operator{keytype(d),valtype(d)}(ks, vs)
+            (gate_count % truncate_every == 0) && (Or = truncation(Or))
+        end
+    end
+
+    # Re-symmetrize back into OperatorTS and update O in place
+    Ots = OperatorTS{Ls,Ps}(Or)
+    empty!(O.strings)
+    empty!(O.coeffs)
+    append!(O.strings, Ots.strings)
+    append!(O.coeffs, Ots.coeffs)
     return O
 end

--- a/src/trotter.jl
+++ b/src/trotter.jl
@@ -139,34 +139,22 @@ function trotterize(H::Operator{<:PauliStringTS}, dt::Real; order::Integer=2, he
     end
 end
 
-
-"""
-    trotter_step!(O::Operator{<:PauliStringTS}, gates::AbstractVector{<:TrotterGate}; truncation, truncate_every)
-
-Apply one Trotter step to a translation-symmetric operator **in place**.
-`gates` should come from [`trotterize`](@ref) on an `OperatorTS` — they contain
-only the representative generators. This method internally applies every
-translation of each gate and re-symmetrizes the result.
-"""
 function trotter_step!(O::Operator{<:PauliStringTS}, gates::AbstractVector{<:TrotterGate};
                        truncation::Function=identity, truncate_every::Int=1)
     isempty(gates) && return O
     Ls = qubitsize(O)
     Ps = periodicflags(O)
 
-    # Unwrap to representative (plain Operator with PauliString entries)
-    Or = representative(O)
-    d = emptydict(Or)
-
-    gate_count = 0
     # U = V1*V2*...*VL => conjugation applies VL,...,V1 (reverse)
-    for g in Iterators.reverse(gates)
+    for (gi, g) in enumerate(Iterators.reverse(gates))
+        # Unwrap to representative (plain Operator) fresh for each gate group
+        Or = representative(O)
+        d = emptydict(Or)
         G_rep = g.generator
         stheta, ctheta = sincos(g.theta)
 
         # Apply every translation of this representative gate sequentially
         for s in all_shifts(Ls, Ps)
-            gate_count += 1
             G = shift(G_rep, Ls, Ps, s)
             phase = (1.0im)^ycount(G)
 
@@ -187,15 +175,15 @@ function trotter_step!(O::Operator{<:PauliStringTS}, gates::AbstractVector{<:Tro
                 @inbounds vs[j] = v
             end
             Or = Operator{keytype(d),valtype(d)}(ks, vs)
-            (gate_count % truncate_every == 0) && (Or = truncation(Or))
         end
-    end
 
-    # Re-symmetrize back into OperatorTS and update O in place
-    Ots = OperatorTS{Ls,Ps}(Or)
-    empty!(O.strings)
-    empty!(O.coeffs)
-    append!(O.strings, Ots.strings)
-    append!(O.coeffs, Ots.coeffs)
+        # Re-symmetrize after each gate group — keeps O compact in TS form
+        O_new = OperatorTS{Ls,Ps}(Or)
+        (gi % truncate_every == 0) && (O_new = truncation(O_new))
+        empty!(O.strings)
+        empty!(O.coeffs)
+        append!(O.strings, O_new.strings)
+        append!(O.coeffs, O_new.coeffs)
+    end
     return O
 end

--- a/test/trotter.jl
+++ b/test/trotter.jl
@@ -87,3 +87,88 @@ end
     trotter_step!(O, TrotterGate{P2,Float64}[])
     @test norm(O - O0) < 1e-14
 end
+
+@testset "trotterize - OperatorTS produces minimal gates" begin
+    N = 6
+    H = Operator(N)
+    H += "Z", 1, "Z", 2
+    H += -0.5, "X", 1
+    Hts = OperatorTS{(N,)}(H)
+
+    g_ts = trotterize(Hts, 0.1; order=1)
+    g_full = trotterize(resum(Hts), 0.1; order=1)
+
+    # TS version has only M representative gates; full has N×M
+    @test length(g_ts) == length(Hts)
+    @test length(g_full) == length(resum(Hts))
+    @test length(g_ts) < length(g_full)
+
+    # order=2
+    g_ts2 = trotterize(Hts, 0.1; order=2)
+    @test length(g_ts2) == 2 * length(Hts) - 1
+
+    # Empty operator
+    Hempty = OperatorTS{(N,)}(Operator(N))
+    @test isempty(trotterize(Hempty, 0.1))
+
+    # Invalid order
+    @test_throws ArgumentError trotterize(Hts, 0.1; order=3)
+end
+
+@testset "trotter_step! - OperatorTS matches resum approach" begin
+    N = 6
+    H = Operator(N)
+    H += "Z", 1, "Z", 2
+    H += -0.3, "X", 1
+    Hts = OperatorTS{(N,)}(H)
+    O = Operator(N)
+    O += "X", 1
+    Ots = OperatorTS{(N,)}(O)
+
+    dt = 0.05
+    truncation(O) = trim(O, 2^14)
+
+    for order in (1, 2)
+        # TS path: trotterize on OperatorTS, trotter_step! on OperatorTS
+        Ots_copy = copy(Ots)
+        g_ts = trotterize(Hts, dt; order=order)
+        trotter_step!(Ots_copy, g_ts; truncation=truncation)
+
+        # resum path: trotterize on full Operator, trotter_step! on full Operator
+        Or = representative(copy(Ots))
+        g_full = trotterize(resum(Hts), dt; order=order)
+        trotter_step!(Or, g_full; truncation=truncation)
+        Ots_from_full = OperatorTS{(N,)}(Or)
+
+        # Both should give the same result
+        @test norm(resum(Ots_copy) - resum(Ots_from_full)) / norm(resum(Ots_from_full)) < 1e-10
+    end
+end
+
+@testset "trotter_step! - OperatorTS vs exact Heisenberg" begin
+    N = 4
+    H = Operator(N)
+    H += "Z", 1, "Z", 2
+    H += -0.5, "X", 1
+    Hts = OperatorTS{(N,)}(H)
+    O = Operator(N)
+    O += "X", 1
+    Ots = OperatorTS{(N,)}(O)
+
+    dt = 0.02
+    Mex = heisenberg_exact(resum(Hts), resum(Ots), dt)
+
+    Ots_copy = copy(Ots)
+    g = trotterize(Hts, dt; order=2)
+    trotter_step!(Ots_copy, g)
+    @test norm(Matrix(resum(Ots_copy)) - Mex) < 1e-6
+end
+
+@testset "trotter_step! - OperatorTS empty gates unchanged" begin
+    N = 4
+    Ots = OperatorTS{(N,)}(Operator(N) + ("Z", 1))
+    Ots0 = copy(Ots)
+    P = paulistringtype(N)
+    trotter_step!(Ots, TrotterGate{P,Float64}[])
+    @test norm(Ots - Ots0) < 1e-14
+end


### PR DESCRIPTION
Closes #78

## Summary

Adds specialized `trotterize` and `trotter_step!` methods for `OperatorTS` that exploit translation symmetry to use a minimal gate set.

**Before:** `_evolve` with `Trotter()` on an `OperatorTS` called `resum(H)` to expand the Hamiltonian into all N×M terms, built N×M Trotter gates, and applied them to the representative.

**After:** `trotterize(H::OperatorTS, dt)` builds only M gates from the representative (unit-cell) terms. `trotter_step!` for `OperatorTS` internally applies every translation of each representative gate and re-symmetrizes the result. The `_evolve` method now stays in `OperatorTS` space throughout — no `resum` call needed.

## Changes

### `src/trotter.jl`
- **`trotterize(H::Operator{<:PauliStringTS}, ...)`** — builds Lie (M gates) or Strang (2M−1 gates) gate list from `representative(H)` only.
- **`trotter_step!(O::Operator{<:PauliStringTS}, gates; ...)`** — unwraps O to its representative, applies each gate with all translation shifts via `all_shifts`/`shift`, then re-symmetrizes back into `OperatorTS`.
- Updated docstring on existing `trotterize` for plain `Operator`.

### `src/evolution.jl`
- Replaced the `_evolve(::Trotter, H::OperatorTS, O::OperatorTS, ...)` method to use the new `trotterize` and `trotter_step!` directly, keeping `O` as `OperatorTS` throughout the loop (no more `resum` + `representative` round-trip).

### `test/trotter.jl`
- **Gate count test:** verifies TS `trotterize` produces M gates vs N×M from the full operator.
- **Equivalence test:** confirms the TS path (`trotterize` on OperatorTS → `trotter_step!` on OperatorTS) matches the old resum path for both order 1 and order 2.
- **Accuracy test:** checks TS Trotter step against exact Heisenberg evolution on a small system.
- **Empty gates test:** verifies empty gate list leaves OperatorTS unchanged.

## Example

For a nearest-neighbor Hamiltonian on N=100 sites with 2 terms per unit cell:

```julia
Hts = OperatorTS{(100,)}(H)  # 2 representative terms

# Before: 200 gates (order 1), 399 gates (order 2)
gates_old = trotterize(resum(Hts), dt)

# After: 2 gates (order 1), 3 gates (order 2)
gates_new = trotterize(Hts, dt)
```

The computational cost per step is the same (same total number of commutators), but gate construction and memory usage scale with M instead of N×M.