### PR TITLE
Add OperatorMathLinkTS: MathLink support for translation-symmetric operators

### DIFF
--- a/ext/MathLinkPauliStringsExt.jl
+++ b/ext/MathLinkPauliStringsExt.jl
@@ -183,7 +183,7 @@ end
 using PauliStrings: qubitsize
 function LinearAlgebra.norm(o::Operator{P, MathLinkNumber}; normalize=false) where P<:PauliStringTS
     Ls = qubitsize(o)
-    scale = MathLinkNumber(2^Base.prod(Ls))
+    scale = MathLinkNumber(W"Sqrt"(2^(Base.prod(Ls))))
     n = sqrt(trace_product(o', o; scale = scale))
     if normalize
         return n / MathLinkNumber(W"Sqrt"(2^(qubitlength(o))))

--- a/ext/MathLinkPauliStringsExt.jl
+++ b/ext/MathLinkPauliStringsExt.jl
@@ -3,7 +3,7 @@ using LinearAlgebra
 using PauliStrings
 using MathLink
 using ProgressBars: ProgressBar
-export OperatorMathLink, simplify_operator, simplify, lanczos
+export OperatorMathLink, OperatorMathLinkTS, simplify_operator, simplify, lanczos
 
 # Define MathLinkNumber, a Number type that wraps MathLink expressions
 # ---------------------------------------------------------------------
@@ -109,6 +109,52 @@ function Base.:+(o::Operator, args::Tuple{MathLink.WTypes,Vararg{Any}})
 end
 
 """
+    OperatorMathLinkTS{Ls}()
+    OperatorMathLinkTS{Ls}(O::Operator; full=false)
+
+Creates a translation-symmetric operator with [`MathLinkNumber`](@ref) coefficients.
+If `full=false`, `O` is treated as a local orbit representative. If `full=true`,
+`O` is treated as the full translation-symmetric operator and is divided by the
+number of translations before constructing the orbit-representative storage.
+"""
+function (::Type{PauliStrings.OperatorMathLinkTS{Ls}})() where {Ls}
+    length(Ls) == 1 || error("OperatorMathLinkTS currently supports 1D translation symmetry only")
+    Ots = OperatorTS1D(Base.prod(Ls))
+    return Operator{paulistringtype(Ots),MathLinkNumber}()
+end
+
+function PauliStrings.OperatorMathLinkTS{Ls}(O::Operator; full::Bool=false) where {Ls}
+    Ls == (qubitlength(O),) || error("OperatorMathLinkTS{$Ls} expects an operator on $(Base.prod(Ls)) qubits, got $(qubitlength(O))")
+    Ots = OperatorTS1D(O; full=full)
+    return Operator{paulistringtype(Ots),MathLinkNumber}(Ots.strings, mathlink_number.(Ots.coeffs))
+end
+
+
+mathlink_number(c::MathLinkNumber) = c
+mathlink_number(c::Number) = MathLinkNumber(c)
+
+function Base.:+(o::Operator{P,MathLinkNumber}, args::Tuple{Number,Vararg{Any}}) where {P<:PauliStringTS}
+    o1 = deepcopy(o)
+    c = args[1]
+    pauli = fill('1', qubitlength(o1))
+    for i in 2:2:length(args)
+        symbol = args[i]
+        site = args[i+1]::Int
+        if symbol in ("X", "Y", "Z", 'X', 'Y', 'Z')
+            pauli[site] = symbol isa Char ? symbol : only(symbol)
+        else
+            return invoke(Base.:+, Tuple{Operator,Tuple{Number,Vararg{Any}}}, o, args)
+        end
+    end
+    PauliStrings.add_string(o1, join(pauli), c)
+    return compress(o1)
+end
+
+Base.:+(o::Operator{P,MathLinkNumber}, args::Tuple{Vararg{Any}}) where {P<:PauliStringTS} = o + (1, args...)
+Base.:-(o::Operator{P,MathLinkNumber}, args::Tuple{Number,Vararg{Any}}) where {P<:PauliStringTS} = o + (-args[1], args[2:end]...)
+Base.:-(o::Operator{P,MathLinkNumber}, args::Tuple{Vararg{Any}}) where {P<:PauliStringTS} = o + (-1, args...)
+
+"""
     simplify_operator(o::Operator{P, MathLinkNumber}; assumptions=nothing) where {P}
 
 Simplifies a `Operator{P, MathLinkNumber}` using Mathematica's `Simplify` function.
@@ -137,7 +183,7 @@ end
 using PauliStrings: qubitsize
 function LinearAlgebra.norm(o::Operator{P, MathLinkNumber}; normalize=false) where P<:PauliStringTS
     Ls = qubitsize(o)
-    scale = MathLinkNumber(W"Sqrt"(2^(Base.prod(Ls))))
+    scale = MathLinkNumber(2^Base.prod(Ls))
     n = sqrt(trace_product(o', o; scale = scale))
     if normalize
         return n / MathLinkNumber(W"Sqrt"(2^(qubitlength(o))))

--- a/src/ext.jl
+++ b/src/ext.jl
@@ -9,5 +9,5 @@ function substitute_operator() end
 # MathLink
 export OperatorMathLink, OperatorMathLinkTS, simplify_operator, simplify
 function OperatorMathLink() end
-function OperatorMathLinkTS() end
+struct OperatorMathLinkTS{Ls} end
 function simplify() end

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -88,6 +88,8 @@ function PauliStringTS{Ls,Ps}(p::PauliString) where {Ls,Ps}
 end
 
 PauliStringTS{Ls}(pauli::AbstractString) where {Ls} = PauliStringTS{Ls}(PauliString(pauli))
+PauliStringTS{Ls,Ps}(pauli::AbstractString) where {Ls,Ps} = PauliStringTS{Ls,Ps}(PauliString(pauli))
+PauliStringTS{Ls,Ps,T}(pauli::AbstractString) where {Ls,Ps,T} = PauliStringTS{Ls,Ps}(PauliString{Base.prod(Ls),T}(pauli))
 
 
 """

--- a/test/mathlink.jl
+++ b/test/mathlink.jl
@@ -15,6 +15,13 @@ function ising(h, N)
     return H
 end
 
+function ising_ts(h, N)
+    H = OperatorMathLinkTS{(N,)}()
+    H += h, "X", 1
+    H += "Z", 1, "Z", 2
+    return H
+end
+
 bn_strings = [
 "Times[2, Power[2, Rational[1, 2]]]",
 "Power[Plus[8, Times[8, Power[h, 2]]], Rational[1, 2]]",
@@ -42,4 +49,31 @@ end
         @test string(b) == bn_str
     end
 
+end
+
+@testset "OperatorMathLinkTS construction" begin
+    N = 10
+
+    O = Operator(N) + (1, "X", 1)
+    Ots = OperatorMathLinkTS{(N,)}(O)
+    Oml = OperatorMathLink(N) + (1, "X", 1)
+    @test Ots isa Operator{<:PauliStringTS}
+    @test length(Ots) == 1
+    @test typeof(Ots.coeffs[1]) == typeof(Oml.coeffs[1])
+
+    Hts = ising_ts(W`h`, N)
+    @test Hts isa Operator{<:PauliStringTS}
+    @test length(Hts) == 2
+end
+
+@testset "lanczos with OperatorMathLinkTS" begin
+    N = 10
+    O = OperatorMathLinkTS{(N,)}()
+    O += 1, "X", 1
+    H = ising_ts(W`h`, N)
+    assumptions = W`Assumptions -> h > 0`
+    bn = lanczos(H, O, 5; assumptions=assumptions)
+    for (b, bn_str) in zip(bn, bn_strings)
+        @test string(b) == bn_str
+    end
 end


### PR DESCRIPTION
# Description

Closes #81

## What's New

This PR adds `OperatorMathLinkTS` to combine MathLink symbolic coefficients with the existing `OperatorTS1D` translation-symmetric storage without materializing the full translation-symmetric operator.

### Added

`OperatorMathLinkTS{(N,)}()` Empty constructor.

`OperatorMathLinkTS{(N,)}(O)` Conversion constructor.

`+=`, `-=` support for adding and subtracting symbolic or numeric Pauli terms to the TS operator.

`PauliStringTS{Ls,Ps}("X111")` String constructor.

`PauliStringTS{Ls,Ps,T}("X111")` Fully typed string constructor.

# Demo

The following Julia script compares the output generated by `OperatorMathLink` and `OperatorMathLinkTS`.

```julia
using MathLink
using PauliStrings
using Test

function ising(N, h)
    H = OperatorMathLink(N)
    for i in 1:N
        H += h, "X", i
    end
    for i in 1:N
        H += "Z", i, "Z", mod1(i + 1, N)
    end
    return H
end

function xtot(N)
    O = OperatorMathLink(N)
    for i in 1:N
        O += 1, "X", i
    end
    return O
end

function ising_ts(N, h)
    H = OperatorMathLinkTS{(N,)}()
    H += h, "X", 1
    H += "Z", 1, "Z", 2
    return H
end

function xtot_ts(N)
    O = OperatorMathLinkTS{(N,)}()
    O += 1, "X", 1
    return O
end

function alignment_table(orig, ts)
    header_orig = rpad("Original", 45)
    lines = ["$header_orig | TS Version", "-"^90]

    for (i, (o, t)) in enumerate(zip(orig, ts))
        str_orig = rpad(string(o), 42)
        push!(lines, "b_$i: $str_orig | $(string(t))")
    end
    return join(lines, "\n")
end

function run_comparison()
    N = 10
    assumptions = W`Assumptions -> h > 0`
    steps = 5

    bn_orig, bn_ts = redirect_stdout(devnull) do
        O_orig = xtot(N)
        H_orig = ising(N, W`h`)
        bn_orig_calc = lanczos(H_orig, O_orig, steps; assumptions=assumptions)

        O_ts = xtot_ts(N)
        H_ts = ising_ts(N, W`h`)
        bn_ts_calc = lanczos(H_ts, O_ts, steps; assumptions=assumptions)

        return bn_orig_calc, bn_ts_calc
    end

    println("\n=== Comparison Results ===")
    println(alignment_table(bn_orig, bn_ts))
    println("\n=== Test Summary ===")

    @testset "OperatorMathLink vs OperatorMathLinkTS" begin
        for i in 1:steps
            str_orig = string(bn_orig[i])
            str_ts = string(bn_ts[i])

            math_cmd = "FullSimplify[(($str_orig)^2) - (($str_ts)^2), Assumptions -> h > 0]"
            result = MathLink.weval(W"ToExpression"(math_cmd))

            @test result == 0
        end
    end
end

run_comparison()
```

### Result:
<img width="873" height="532" alt="image" src="https://github.com/user-attachments/assets/d7ef73a6-ebf0-4664-87d7-f6020f65a169" />

# How Has This Been Tested?
I ran the main non-MathLink test suite locally:
```julia --project=. test/runtests.jl```:
<img width="423" height="131" alt="image" src="https://github.com/user-attachments/assets/8a9e4e78-2d43-4918-a859-0443046b942f" />


I ran the MathLink test suite locally:
```julia --project=. test/mathlink.jl```:
<img width="863" height="221" alt="image" src="https://github.com/user-attachments/assets/26283ca9-d297-4f6b-920c-a1cc7e2a9376" />




# AI Disclosure: 
I used ChatGPT/Codex to help reason about combining OperatorMathLink coefficients with OperatorTS1D storage and to review and correct the changes I manually made. I manually reviewed the changes and tested the test suite locally.
