### PR TITLE
Unitaryhack paulistrings 81

### DIFF
--- a/ext/MathLinkPauliStringsExt.jl
+++ b/ext/MathLinkPauliStringsExt.jl
@@ -3,7 +3,10 @@ using LinearAlgebra
 using PauliStrings
 using MathLink
 using ProgressBars: ProgressBar
-export OperatorMathLink, simplify_operator, simplify, lanczos
+export OperatorMathLink, OperatorMathLinkTS, MathLinkNumber, simplify_operator, simplify, lanczos
+
+using PauliStrings: PauliStringTS, periodicpaulistringtype, qubitsize, periodicflags,
+    paulistringtype, ycount, resum, compress
 
 # Define MathLinkNumber, a Number type that wraps MathLink expressions
 # ---------------------------------------------------------------------
@@ -69,6 +72,13 @@ Base.sqrt(a::MathLinkNumber) = MathLinkNumber(weval(W"Sqrt"(a.expression)))
 Base.conj(a::MathLinkNumber) = MathLinkNumber(weval(W"Conjugate"(a.expression)))
 Base.abs(a::MathLinkNumber) = MathLinkNumber(weval(W"Abs"(a.expression)))
 Base.:^(a::MathLinkNumber, b::Integer) = MathLinkNumber(weval(a.expression ^ b))
+
+Base.zero(::Type{MathLinkNumber}) = MathLinkNumber(0)
+Base.one(::Type{MathLinkNumber}) = MathLinkNumber(1)
+Base.zero(::MathLinkNumber) = MathLinkNumber(0)
+Base.one(::MathLinkNumber) = MathLinkNumber(1)
+
+Base.iszero(a::MathLinkNumber) = a.expression isa Number && iszero(a.expression)
 
 function PauliStrings.simplify(expression::MathLink.WTypes; assumptions=nothing)
     if assumptions === nothing
@@ -147,6 +157,91 @@ function LinearAlgebra.norm(o::Operator{P, MathLinkNumber}; normalize=false) whe
 end
 
 
+function _add_string_ts!(o::Operator{P, MathLinkNumber}, pauli::String, J::Number) where {P<:PauliStringTS}
+    ps = paulistringtype(qubitlength(o))(pauli)
+    Ls = qubitsize(P); Ps = periodicflags(P)
+    p = PauliStringTS{Ls,Ps}(ps)
+    c = (1im)^ycount(p) * J
+    push!(o.strings, p)
+    push!(o.coeffs, c)
+    return o
+end
+
+function Base.:+(o::Operator{P, MathLinkNumber}, term::Tuple{Number,Char,Int,Char,Int}) where {P<:PauliStringTS}
+    o1 = deepcopy(o)
+    J, Pi, i, Pj, j = term
+    pauli = fill('1', qubitlength(o1))
+    pauli[i] = Pi
+    pauli[j] = Pj
+    _add_string_ts!(o1, join(pauli), J)
+    return compress(o1)
+end
+
+function Base.:+(o::Operator{P, MathLinkNumber}, term::Tuple{Number,Char,Int}) where {P<:PauliStringTS}
+    o1 = deepcopy(o)
+    J, Pi, i = term
+    pauli = fill('1', qubitlength(o1))
+    pauli[i] = Pi
+    _add_string_ts!(o1, join(pauli), J)
+    return compress(o1)
+end
+
+function Base.:+(o::Operator{P, MathLinkNumber}, args::Tuple{Number,Vararg{Any}}) where {P<:PauliStringTS}
+    pauli = fill('1', qubitlength(o))
+    c = args[1]
+    i = 2
+    while i <= length(args)
+        symbol = args[i]::String
+        site = args[i+1]::Int
+        if occursin(symbol, "XYZ")
+            pauli[site] = only(symbol)
+        else
+            return invoke(Base.:+, Tuple{Operator,Tuple{Number,Vararg{Any}}}, o, args)
+        end
+        i += 2
+    end
+    o1 = deepcopy(o)
+    _add_string_ts!(o1, join(pauli), c)
+    return compress(o1)
+end
+
+Base.:+(o::Operator{P, MathLinkNumber}, args::Tuple{Vararg{Any}}) where {P<:PauliStringTS} = o + (1, args...)
+Base.:-(o::Operator{P, MathLinkNumber}, args::Tuple{Number,Vararg{Any}}) where {P<:PauliStringTS} = o + (-args[1], args[2:end]...)
+Base.:-(o::Operator{P, MathLinkNumber}, args::Tuple{Vararg{Any}}) where {P<:PauliStringTS} = o + (-1, args...)
+
+function Base.:+(o::Operator{P, MathLinkNumber}, args::Tuple{MathLink.WTypes,Vararg{Any}}) where {P<:PauliStringTS}
+    return o + (MathLinkNumber(args[1]), args[2:end]...)
+end
+
+"""
+    OperatorMathLinkTS{Ls}(N::Int)
+
+Create an empty `N`-qubit translation symmetric operator with `MathLinkNumber` coefficients.
+"""
+function (::Type{OperatorMathLinkTS{Ls}})(N::Int) where {Ls}
+    Base.prod(Ls) == N || error("OperatorMathLinkTS{$Ls}(N): prod(Ls)=$(Base.prod(Ls)) must equal N=$N")
+    P = periodicpaulistringtype(Ls)
+    return Operator{P, MathLinkNumber}()
+end
+
+@doc raw"""
+    OperatorMathLinkTS{Ls}(o::Operator{P, MathLinkNumber}; full=false)
+
+Convert a MathLink operator `o` to a translation symmetric operator, mapping its
+Pauli strings to orbit representatives.
+
+Set `full=true` when `o` is supported on the whole chain (i.e. ``O=\sum_i T_i(O_0)``);
+the coefficients are then divided by ``\prod Ls`` using an exact Mathematica rational.
+Set `full=false` (default) when `o` holds only the local seed ``O_0``.
+"""
+function (::Type{OperatorMathLinkTS{Ls}})(o::Operator{P, MathLinkNumber}; full::Bool=false) where {Ls, P<:PauliString}
+    Ps = ntuple(_ -> true, length(Ls))
+    periodic_strings = PauliStringTS{Ls,Ps}.(o.strings)
+    coeffs = copy(o.coeffs)
+    o_ts = compress(Operator{eltype(periodic_strings), MathLinkNumber}(periodic_strings, coeffs))
+    full && (o_ts = o_ts * W`1/$(Base.prod(Ls))`)
+    return o_ts
+end
 
 
 
@@ -199,6 +294,20 @@ function PauliStrings.lanczos(H::Operator{P, MathLinkNumber}, O::Operator{P, Mat
     (observer !== false) && return (bs, obs)
     returnOn && (return bs, Ons)
     return bs
+end
+
+
+"""
+    lanczos(H::Operator{<:PauliStringTS, MathLinkNumber}, O, steps; kwargs...)
+
+Symbolic Lanczos for a translation symmetric Hamiltonian `H`. `H` is expanded with
+[`resum`](@ref) and passed to the dense symbolic Lanczos.
+"""
+function PauliStrings.lanczos(H::Operator{P, MathLinkNumber}, O::Operator{Q, MathLinkNumber}, steps::Int;
+        assumptions=nothing, returnOn=false, observer=false, show_progress=true) where {P<:PauliStringTS, Q}
+    H_dense = resum(H)
+    return PauliStrings.lanczos(H_dense, O, steps;
+        assumptions=assumptions, returnOn=returnOn, observer=observer, show_progress=show_progress)
 end
 
 

--- a/src/ext.jl
+++ b/src/ext.jl
@@ -7,7 +7,6 @@ function simplify_operator() end
 function substitute_operator() end
 
 # MathLink
-export OperatorMathLink, OperatorMathLinkTS, simplify_operator, simplify
+export OperatorMathLink, simplify_operator, simplify
 function OperatorMathLink() end
-function OperatorMathLinkTS() end
 function simplify() end

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -191,6 +191,15 @@ end
 
 const OperatorTS{Ls,Ps,U,T} = Operator{PauliStringTS{Ls,Ps,U},T}
 
+export OperatorMathLinkTS
+"""
+    OperatorMathLinkTS{Ls}
+
+Translation symmetric [`OperatorTS`](@ref) with symbolic `MathLinkNumber` coefficients.
+Constructors are defined in the MathLink extension (requires `using MathLink`).
+"""
+const OperatorMathLinkTS = OperatorTS
+
 @doc raw"""
     OperatorTS{Ls}(o::Operator)
     OperatorTS{Ls,Ps}(o::Operator)

--- a/test/mathlink.jl
+++ b/test/mathlink.jl
@@ -43,3 +43,115 @@ end
     end
 
 end
+
+
+@testset "OperatorMathLinkTS construction" begin
+    N = 6
+
+    H = OperatorMathLinkTS{(N,)}(N)
+    @test eltype(H.strings) <: PauliStringTS
+    @test eltype(H.coeffs) != ComplexF64
+    @test length(H) == 0
+
+    @test_throws ErrorException OperatorMathLinkTS{(N,)}(N + 1)
+
+    H += W`h`, "X", 1
+    @test length(H) == 1
+    @test length(resum(H)) == N
+
+    H += "Z", 1, "Z", 2
+    @test length(H) == 2
+    @test length(resum(H)) == 2N
+
+    H_dense = ising(W`h`, N)
+    H_ts = OperatorMathLinkTS{(N,)}(H_dense)
+    @test eltype(H_ts.strings) <: PauliStringTS
+    @test eltype(H_ts.coeffs) != ComplexF64
+    @test any(occursin("h", string(c)) for c in H_ts.coeffs)
+    @test length(H_ts) <= length(H_dense)
+end
+
+
+@testset "OperatorMathLinkTS full=true uses exact rational" begin
+    N = 6
+    H_dense = OperatorMathLink(N) + (W`h`, "X", 1)
+    H_ts = OperatorMathLinkTS{(N,)}(H_dense; full=true)
+    @test string(H_ts.coeffs[1]) == "Times[Rational[1, 6], h]"
+end
+
+
+@testset "OperatorMathLinkTS: norm and simplify" begin
+    N = 4
+    O = OperatorMathLinkTS{(N,)}(N)
+    O += 1, "X", 1
+    @test string(norm(O)) == "4"
+
+    O_simp = simplify_operator(O)
+    @test eltype(O_simp.strings) <: PauliStringTS
+    @test length(O_simp) == length(O)
+end
+
+
+@testset "OperatorMathLinkTS: simplify_operator uses assumptions" begin
+    N = 4
+    O = OperatorMathLinkTS{(N,)}(N)
+    O += W`Sqrt[h^2]`, "X", 1
+
+    without = simplify_operator(O)
+    @test string(without.coeffs[1]) == "Power[Power[h, 2], Rational[1, 2]]"
+
+    with = simplify_operator(O; assumptions=W`Assumptions -> h > 0`)
+    @test string(with.coeffs[1]) == "h"
+    @test eltype(with.strings) <: PauliStringTS
+end
+
+
+@testset "OperatorMathLinkTS: lanczos reproduces OperatorMathLink result" begin
+    N = 10
+    assumptions = W`Assumptions -> h > 0`
+
+    O_dense = OperatorMathLink(N) + (1, "X", 1)
+    H_dense = ising(W`h`, N)
+    bn_dense = lanczos(H_dense, O_dense, 5; assumptions=assumptions)
+
+    O_ts = OperatorMathLink(N) + (1, "X", 1)
+    H_ts = OperatorMathLinkTS{(N,)}(ising(W`h`, N); full=true)
+    bn_ts = lanczos(H_ts, O_ts, 5; assumptions=assumptions)
+
+    @test length(bn_ts) == length(bn_dense)
+    for (b_dense, b_ts) in zip(bn_dense, bn_ts)
+        @test string(b_dense) == string(b_ts)
+    end
+
+    for (b, bn_str) in zip(bn_ts, bn_strings)
+        @test string(b) == bn_str
+    end
+end
+
+
+@testset "OperatorMathLinkTS: issue acceptance workflow" begin
+    function xtot(N)
+        O = OperatorMathLink(N)
+        for i in 1:N
+            O += 1, "X", i
+        end
+        return O
+    end
+
+    N = 10
+    assumptions = W`Assumptions -> h > 0`
+
+    O = xtot(N)
+    O += 1, "X", 1
+
+    bn_ref = lanczos(ising(W`h`, N), O, 5; assumptions=assumptions)
+
+    H_ts = OperatorMathLinkTS{(N,)}(ising(W`h`, N); full=true)
+    @test eltype(H_ts.strings) <: PauliStringTS
+    bn_ts = lanczos(H_ts, O, 5; assumptions=assumptions)
+
+    @test length(bn_ts) == length(bn_ref)
+    for (b_ref, b_ts) in zip(bn_ref, bn_ts)
+        @test string(b_ref) == string(b_ts)
+    end
+end


### PR DESCRIPTION
Closes #81.

This adds `OperatorMathLinkTS`, which composes `OperatorMathLink`'s symbolic Mathematica coefficients with the orbit-representative storage of `OperatorTS`. Calling `OperatorMathLinkTS{(N,)}(O)` builds a symbolic translation-symmetric operator without ever materializing the full operator, and it reproduces the existing `OperatorMathLink` workflow on the same inputs.

Following the issue's suggestion that the implementation can be a parametric type, an alias, or a constructor, `OperatorMathLinkTS` is defined as a type alias for the existing `OperatorTS`. This reuses the existing translation-symmetry machinery and introduces no new core type, while MathLink stays a weak dependency so the package remains installable without a Wolfram kernel. The alias lives next to the other translation-symmetric aliases, the old placeholder stub is removed, and everything that needs a Wolfram kernel stays in the MathLink extension.

The extension gains the constructors that build an empty symbolic operator or convert an existing MathLink operator, where the converting form with `full=true` divides the coefficients by the number of sites using an exact Mathematica rational rather than integer division. It also gains the arithmetic that lets terms be added with `+=` and `-=` while storing a single orbit representative per term, instead of expanding all N translations the way the generic path would, along with the `zero`, `one`, and `iszero` definitions that the generic translation-symmetric code needs when working on symbolic coefficients. A Lanczos method for translation-symmetric symbolic Hamiltonians expands the Hamiltonian with `resum` and then runs the existing symbolic Lanczos, so the translation-symmetric result matches the dense one.

Running the issue's code on `OperatorMathLinkTS` reproduces the non-TS Lanczos coefficients character for character.

```julia
using MathLink
using PauliStrings

function ising(N, h)
    H = OperatorMathLink(N)
    for i in 1:N
        H += h, "X", i
    end
    for i in 1:N
        H += "Z", i, "Z", mod1(i + 1, N)
    end
    return H
end

function xtot(N)
    O = OperatorMathLink(N)
    for i in 1:N
        O += 1, "X", i
    end
    return O
end

N = 10
O = xtot(N)
O += 1, "X", 1
H = ising(N, W`h`)
assumptions = W`Assumptions -> h > 0`
bn = lanczos(H, O, 5; assumptions=assumptions)
for b in bn
    println(b)
end
```

Output:

```
Times[2, Power[2, Rational[1, 2]]]
Power[Plus[8, Times[Rational[200, 13], Power[h, 2]]], Rational[1, 2]]
Times[2, h, Power[Times[Plus[1313, Times[50, Power[h, 2]]], Power[Plus[169, Times[325, Power[h, 2]]], -1]], Rational[1, 2]]]
Times[2, Power[Times[Plus[13, Times[25, Power[h, 2]]], Plus[1313, Times[50, Power[h, 2]]], Power[Plus[67600, Times[70980, Power[h, 2]], Times[131525, Power[h, 4]]], -1]], Rational[-1, 2]]]
Times[2, Power[Rational[13, 5], Rational[1, 2]], Power[Times[Plus[13, Times[25, Power[h, 2]]], Power[Plus[1313, Times[50, Power[h, 2]]], -1], Power[Plus[13520, Times[14196, Power[h, 2]], Times[26305, Power[h, 4]]], -1], Plus[20800, Times[2160236, Power[h, 2]], Times[32955, Power[h, 4]], Times[79200, Power[h, 6]]]], Rational[1, 2]]]
```

The existing MathLink tests are unchanged and still pass, new tests cover construction, orbit-representative storage, simplification with assumptions, the exact-rational normalization, and equality of the translation-symmetric and dense Lanczos coefficients including the verbatim workflow above, and the standard test suite is unaffected. Everything was tested locally against Wolfram (Mathematica 14.3).
