### PR TITLE
Reduce duplication through `keys`, `values` and `pairs`

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -1,3 +1,4 @@
+
 using SparseArrays
 
 # TODO: build the sparse matrix efficiently column by column

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -1,4 +1,3 @@
-
 using SparseArrays
 
 # TODO: build the sparse matrix efficiently column by column
@@ -15,9 +14,9 @@ function frustration_graph(o::Operator)
     o = Operator(o)
     n = length(o)
     G = spzeros(Int, n, n)
-    for i in 1:n
-        for j in 1:n
-            p, k = commutator(o.strings[i], o.strings[j])
+    for (i, pᵢ) in enumerate(keys(o))
+        for (j, pⱼ) in enumerate(keys(o))
+            _, k = commutator(pᵢ, pⱼ)
             if k != 0
                 G[i, j] = 1
             end

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,3 +1,4 @@
+
 import LinearAlgebra as la
 using SparseArrays
 
@@ -58,15 +59,14 @@ julia> A
 (6.0 - 0.0im) 1XXY
 ```
 """
-function set_coeffs(o::AbstractOperator, coeffs::Vector{T}) where {T <: Number}
+function set_coeffs(o::AbstractOperator, coeffs::Vector{T}) where {T<:Number}
     length(o) != length(coeffs) && error("length(o) != length(coefs)")
     for i in 1:length(o)
         o.coeffs[i] = (1im)^ycount(o.strings[i]) * coeffs[i]
     end
-    return
 end
 
-set_coefs(o::AbstractOperator, coeffs::Vector{T}) where {T <: Number} = set_coeffs(o, coefs)
+set_coefs(o::AbstractOperator, coeffs::Vector{T}) where {T<:Number} = set_coeffs(o, coefs)
 
 """
 add a pauli string term to an operator
@@ -83,13 +83,13 @@ function string_from_inds(ind::Vector{Int})
     l::Vector{Char} = []
     paulis = ['1', 'X', 'Y', 'Z']
     for i in ind
-        push!(l, paulis[i + 1])
+        push!(l, paulis[i+1])
     end
     return join(l)
 end
 
 
-function Base.:+(o::Operator, term::Tuple{Number, Char, Int, Char, Int})
+function Base.:+(o::Operator, term::Tuple{Number,Char,Int,Char,Int})
     o1 = deepcopy(o)
     J, Pi, i, Pj, j = term
     pauli = fill('1', qubitlength(o1))
@@ -101,7 +101,7 @@ function Base.:+(o::Operator, term::Tuple{Number, Char, Int, Char, Int})
 end
 
 
-function Base.:+(o::Operator, term::Tuple{Number, Char, Int})
+function Base.:+(o::Operator, term::Tuple{Number,Char,Int})
     o1 = deepcopy(o)
     J, Pi, i = term
     pauli = fill('1', qubitlength(o1))
@@ -111,8 +111,8 @@ function Base.:+(o::Operator, term::Tuple{Number, Char, Int})
     return compress(o1)
 end
 
-Base.:+(o::Operator, term::Tuple{Char, Int, Char, Int}) = o + (1, term...)
-Base.:+(o::Operator, term::Tuple{Char, Int}) = o + (1, term...)
+Base.:+(o::Operator, term::Tuple{Char,Int,Char,Int}) = o + (1, term...)
+Base.:+(o::Operator, term::Tuple{Char,Int}) = o + (1, term...)
 
 
 """
@@ -158,13 +158,13 @@ julia> A
 (2.0 - 0.0im) 1XXY
 ```
 """
-function Base.:+(o::Operator, args::Tuple{Number, Vararg{Any}})
+function Base.:+(o::Operator, args::Tuple{Number,Vararg{Any}})
     term = one(o)
     c = args[1]
     for i in 2:2:length(args)
         o2 = zero(o)
         symbol = args[i]::String
-        site = args[i + 1]::Int
+        site = args[i+1]::Int
         if occursin(symbol, "XYZ")
             o2 += only(symbol), site
         elseif occursin(symbol, "SxSySz")
@@ -189,15 +189,15 @@ function Base.:+(o::Operator, args::Tuple{Number, Vararg{Any}})
     return compress(o + c * term)
 end
 Base.:+(o::Operator, args::Tuple{Vararg{Any}}) = o + (1, args...)
-Base.:-(o::Operator, args::Tuple{Number, Vararg{Any}}) = o + (-args[1], args[2:end]...)
+Base.:-(o::Operator, args::Tuple{Number,Vararg{Any}}) = o + (-args[1], args[2:end]...)
 Base.:-(o::Operator, args::Tuple{Vararg{Any}}) = o + (-1, args...)
 
 
-PauliString{N}(args::Vararg{Any}) where {N} = (Operator(N) + args).strings[1]
-PauliStringTS{Ls}(args::Vararg{Any}) where {Ls} = PauliStringTS{Ls, ntuple(i -> true, length(Ls))}(args...)
-PauliStringTS{Ls, Ps}(args::Vararg{Any}) where {Ls, Ps} = PauliStringTS{Ls, Ps}(PauliString{Base.prod(Ls)}(args...))
+PauliString{N}(args::Vararg{Any}) where {N} = (Operator(N)+args).strings[1]
+PauliStringTS{Ls}(args::Vararg{Any}) where {Ls} = PauliStringTS{Ls,ntuple(i -> true, length(Ls))}(args...)
+PauliStringTS{Ls,Ps}(args::Vararg{Any}) where {Ls,Ps} = PauliStringTS{Ls,Ps}(PauliString{Base.prod(Ls)}(args...))
 
-function Base.:+(o::Operator, term::Tuple{Number, String})
+function Base.:+(o::Operator, term::Tuple{Number,String})
     o1 = deepcopy(o)
     c, pauli = term
     if qubitlength(o1) != length(pauli)
@@ -209,10 +209,10 @@ end
 
 Base.:+(o::Operator, term::String) = o + (1, term)
 Base.:-(o::Operator, term::String) = o + (-1, term)
-Base.:-(o::Operator, term::Tuple{Number, String}) = o + (-term[1], term[2])
+Base.:-(o::Operator, term::Tuple{Number,String}) = o + (-term[1], term[2])
 
-Base.:+(o::Operator, term::Tuple{Number, Vector{Int}}) = o + (term[1], string_from_inds(term[2]))
-Base.:-(o::Operator, term::Tuple{Number, Vector{Int}}) = o - (term[1], string_from_inds(term[2]))
+Base.:+(o::Operator, term::Tuple{Number,Vector{Int}}) = o + (term[1], string_from_inds(term[2]))
+Base.:-(o::Operator, term::Tuple{Number,Vector{Int}}) = o - (term[1], string_from_inds(term[2]))
 
 Base.:+(o::Operator, term::Vector{Int}) = o + (1, string_from_inds(term))
 Base.:-(o::Operator, term::Vector{Int}) = o - (1, string_from_inds(term))
@@ -250,6 +250,7 @@ function vw_to_string(v::Unsigned, w::Unsigned, N::Int)
 end
 
 
+
 function Base.show(io::IO, o::AbstractOperator)
     if length(o) == 0
         println(io, "0")
@@ -258,7 +259,7 @@ function Base.show(io::IO, o::AbstractOperator)
     t = scalartype(o)
     terms = collect(pairs(o))
     if t == ComplexF64
-        sort!(terms, by = pc -> (abs(pc.second), pc.first))
+        sort!(terms, by=pc -> (abs(pc.second), pc.first))
     end
     for (p, c) in terms
         phase = 1im^ycount(p)
@@ -267,7 +268,7 @@ function Base.show(io::IO, o::AbstractOperator)
         pauli = string(p)
 
         if t == ComplexF64
-            prefix = "($(round(c, digits = 10))) "
+            prefix = "($(round(c, digits=10))) "
         else
             prefix = "($c) "
         end
@@ -277,7 +278,6 @@ function Base.show(io::IO, o::AbstractOperator)
         join(io, split(pauli, '\n'), space)
         println(io)
     end
-    return nothing
 end
 
 Base.show(io::IO, o::AbstractPauliString) = print(io, string(o))
@@ -320,6 +320,7 @@ pdict = Dict('1' => s0, 'X' => sx, 'Y' => sy, 'Z' => sz)
 pdict_sparse = Dict('1' => sparse(s0), 'X' => sparse(sx), 'Y' => sparse(sy), 'Z' => sparse(sz))
 
 
+
 function string_to_dense(v, w, N)
     pauli, phase = vw_to_string(v, w, N)
     tau = 1
@@ -338,6 +339,7 @@ Convert an operator to a dense matrix.
 op_to_dense(o::Operator) = Matrix(o)
 
 
+
 """
     SparseArrays.sparse(o::Operator)
 
@@ -353,7 +355,7 @@ function SparseArrays.sparse(o::Operator)
     sizehint!(J, length(o) * n)
     sizehint!(V, length(o) * n)
     @inbounds for k in eachindex(o.coeffs, o.strings)
-        c = o.coeffs[k] / (1im^ycount(o.strings[k]))
+        c = o.coeffs[k] / (1im ^ ycount(o.strings[k]))
         sk = sparse(o.strings[k])
         Ii, Jj, Vv = findnz(sk)
         append!(I, Ii)
@@ -364,13 +366,14 @@ function SparseArrays.sparse(o::Operator)
 end
 
 
+
 """
     Matrix(o::Operator)
 
 Convert an operator to a dense matrix.
 """
 Base.Matrix(o::Operator) = Matrix(SparseArrays.sparse(o))
-Base.Matrix(o::OperatorTS{Ls, Ps, U, T} where {Ls, Ps, U, T <: Number}) = Matrix(resum(o))
+Base.Matrix(o::OperatorTS{Ls,Ps,U,T} where {Ls,Ps,U,T<:Number}) = Matrix(resum(o))
 
 """
     get_coeff(o::Operator{P}, p::P) where {P}
@@ -405,6 +408,7 @@ String macro to create a pauli string.
 p_str(pauli) = PauliString(pauli)
 
 
+
 """
     vw_in_o(v::Unsigned, w::Unsigned, o::Operator)
 
@@ -420,8 +424,9 @@ function vw_in_o(v::Unsigned, w::Unsigned, o::Operator)
 end
 
 
+
 function Base.sort(o::Operator)
-    i = sortperm(eachindex(o.coeffs), by = i -> (abs(o.coeffs[i]), o.strings[i]))
+    i = sortperm(eachindex(o.coeffs), by=i -> (abs(o.coeffs[i]), o.strings[i]))
     o2 = typeof(o)(o.strings[i], o.coeffs[i])
     return o2
 end
@@ -454,11 +459,11 @@ function Operator(M::Matrix)
     @assert ispow2(size(M, 1)) "Matrix size must be a power of 2"
     N = Int(log2(size(M, 1)))
     o = Operator(N)
-    for i in 0:(2^N - 1)
-        for j in 0:(2^N - 1)
+    for i in 0:2^N-1
+        for j in 0:2^N-1
             p = paulistringtype(o)(i, j)
             c = inner(M, sparse(p)) / (2.0^N)
-            if abs(c) > 1.0e-16
+            if abs(c) > 1e-16
                 push!(o.strings, p)
                 push!(o.coeffs, c * (1im)^ycount(p))
             end

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,4 +1,3 @@
-
 import LinearAlgebra as la
 using SparseArrays
 
@@ -59,14 +58,15 @@ julia> A
 (6.0 - 0.0im) 1XXY
 ```
 """
-function set_coeffs(o::AbstractOperator, coeffs::Vector{T}) where {T<:Number}
+function set_coeffs(o::AbstractOperator, coeffs::Vector{T}) where {T <: Number}
     length(o) != length(coeffs) && error("length(o) != length(coefs)")
     for i in 1:length(o)
         o.coeffs[i] = (1im)^ycount(o.strings[i]) * coeffs[i]
     end
+    return
 end
 
-set_coefs(o::AbstractOperator, coeffs::Vector{T}) where {T<:Number} = set_coeffs(o, coefs)
+set_coefs(o::AbstractOperator, coeffs::Vector{T}) where {T <: Number} = set_coeffs(o, coefs)
 
 """
 add a pauli string term to an operator
@@ -83,13 +83,13 @@ function string_from_inds(ind::Vector{Int})
     l::Vector{Char} = []
     paulis = ['1', 'X', 'Y', 'Z']
     for i in ind
-        push!(l, paulis[i+1])
+        push!(l, paulis[i + 1])
     end
     return join(l)
 end
 
 
-function Base.:+(o::Operator, term::Tuple{Number,Char,Int,Char,Int})
+function Base.:+(o::Operator, term::Tuple{Number, Char, Int, Char, Int})
     o1 = deepcopy(o)
     J, Pi, i, Pj, j = term
     pauli = fill('1', qubitlength(o1))
@@ -101,7 +101,7 @@ function Base.:+(o::Operator, term::Tuple{Number,Char,Int,Char,Int})
 end
 
 
-function Base.:+(o::Operator, term::Tuple{Number,Char,Int})
+function Base.:+(o::Operator, term::Tuple{Number, Char, Int})
     o1 = deepcopy(o)
     J, Pi, i = term
     pauli = fill('1', qubitlength(o1))
@@ -111,8 +111,8 @@ function Base.:+(o::Operator, term::Tuple{Number,Char,Int})
     return compress(o1)
 end
 
-Base.:+(o::Operator, term::Tuple{Char,Int,Char,Int}) = o + (1, term...)
-Base.:+(o::Operator, term::Tuple{Char,Int}) = o + (1, term...)
+Base.:+(o::Operator, term::Tuple{Char, Int, Char, Int}) = o + (1, term...)
+Base.:+(o::Operator, term::Tuple{Char, Int}) = o + (1, term...)
 
 
 """
@@ -158,13 +158,13 @@ julia> A
 (2.0 - 0.0im) 1XXY
 ```
 """
-function Base.:+(o::Operator, args::Tuple{Number,Vararg{Any}})
+function Base.:+(o::Operator, args::Tuple{Number, Vararg{Any}})
     term = one(o)
     c = args[1]
     for i in 2:2:length(args)
         o2 = zero(o)
         symbol = args[i]::String
-        site = args[i+1]::Int
+        site = args[i + 1]::Int
         if occursin(symbol, "XYZ")
             o2 += only(symbol), site
         elseif occursin(symbol, "SxSySz")
@@ -189,15 +189,15 @@ function Base.:+(o::Operator, args::Tuple{Number,Vararg{Any}})
     return compress(o + c * term)
 end
 Base.:+(o::Operator, args::Tuple{Vararg{Any}}) = o + (1, args...)
-Base.:-(o::Operator, args::Tuple{Number,Vararg{Any}}) = o + (-args[1], args[2:end]...)
+Base.:-(o::Operator, args::Tuple{Number, Vararg{Any}}) = o + (-args[1], args[2:end]...)
 Base.:-(o::Operator, args::Tuple{Vararg{Any}}) = o + (-1, args...)
 
 
-PauliString{N}(args::Vararg{Any}) where {N} = (Operator(N)+args).strings[1]
-PauliStringTS{Ls}(args::Vararg{Any}) where {Ls} = PauliStringTS{Ls,ntuple(i -> true, length(Ls))}(args...)
-PauliStringTS{Ls,Ps}(args::Vararg{Any}) where {Ls,Ps} = PauliStringTS{Ls,Ps}(PauliString{Base.prod(Ls)}(args...))
+PauliString{N}(args::Vararg{Any}) where {N} = (Operator(N) + args).strings[1]
+PauliStringTS{Ls}(args::Vararg{Any}) where {Ls} = PauliStringTS{Ls, ntuple(i -> true, length(Ls))}(args...)
+PauliStringTS{Ls, Ps}(args::Vararg{Any}) where {Ls, Ps} = PauliStringTS{Ls, Ps}(PauliString{Base.prod(Ls)}(args...))
 
-function Base.:+(o::Operator, term::Tuple{Number,String})
+function Base.:+(o::Operator, term::Tuple{Number, String})
     o1 = deepcopy(o)
     c, pauli = term
     if qubitlength(o1) != length(pauli)
@@ -209,10 +209,10 @@ end
 
 Base.:+(o::Operator, term::String) = o + (1, term)
 Base.:-(o::Operator, term::String) = o + (-1, term)
-Base.:-(o::Operator, term::Tuple{Number,String}) = o + (-term[1], term[2])
+Base.:-(o::Operator, term::Tuple{Number, String}) = o + (-term[1], term[2])
 
-Base.:+(o::Operator, term::Tuple{Number,Vector{Int}}) = o + (term[1], string_from_inds(term[2]))
-Base.:-(o::Operator, term::Tuple{Number,Vector{Int}}) = o - (term[1], string_from_inds(term[2]))
+Base.:+(o::Operator, term::Tuple{Number, Vector{Int}}) = o + (term[1], string_from_inds(term[2]))
+Base.:-(o::Operator, term::Tuple{Number, Vector{Int}}) = o - (term[1], string_from_inds(term[2]))
 
 Base.:+(o::Operator, term::Vector{Int}) = o + (1, string_from_inds(term))
 Base.:-(o::Operator, term::Vector{Int}) = o - (1, string_from_inds(term))
@@ -250,25 +250,24 @@ function vw_to_string(v::Unsigned, w::Unsigned, N::Int)
 end
 
 
-
 function Base.show(io::IO, o::AbstractOperator)
     if length(o) == 0
         println(io, "0")
         return
     end
-    N = qubitlength(o)
-    t = eltype(o.coeffs)
+    t = scalartype(o)
+    terms = collect(pairs(o))
     if t == ComplexF64
-        o = sort(o)
+        sort!(terms, by = pc -> (abs(pc.second), pc.first))
     end
-    for (p, c) in zip(o.strings, o.coeffs)
+    for (p, c) in terms
         phase = 1im^ycount(p)
         c /= phase
 
         pauli = string(p)
 
         if t == ComplexF64
-            prefix = "($(round(c, digits=10))) "
+            prefix = "($(round(c, digits = 10))) "
         else
             prefix = "($c) "
         end
@@ -278,6 +277,7 @@ function Base.show(io::IO, o::AbstractOperator)
         join(io, split(pauli, '\n'), space)
         println(io)
     end
+    return nothing
 end
 
 Base.show(io::IO, o::AbstractPauliString) = print(io, string(o))
@@ -287,7 +287,7 @@ Base.show(io::IO, o::AbstractPauliString) = print(io, string(o))
 
 Return the list of coefficient in front of each strings.
 """
-get_coeffs(o::AbstractOperator) = [o.coeffs[i] / (1im)^ycount(o.strings[i]) for i in 1:length(o)]
+get_coeffs(o::AbstractOperator) = [c / (1im)^ycount(p) for (p, c) in pairs(o)]
 
 
 get_coefs(o) = get_coeffs(o)
@@ -320,7 +320,6 @@ pdict = Dict('1' => s0, 'X' => sx, 'Y' => sy, 'Z' => sz)
 pdict_sparse = Dict('1' => sparse(s0), 'X' => sparse(sx), 'Y' => sparse(sy), 'Z' => sparse(sz))
 
 
-
 function string_to_dense(v, w, N)
     pauli, phase = vw_to_string(v, w, N)
     tau = 1
@@ -339,7 +338,6 @@ Convert an operator to a dense matrix.
 op_to_dense(o::Operator) = Matrix(o)
 
 
-
 """
     SparseArrays.sparse(o::Operator)
 
@@ -355,7 +353,7 @@ function SparseArrays.sparse(o::Operator)
     sizehint!(J, length(o) * n)
     sizehint!(V, length(o) * n)
     @inbounds for k in eachindex(o.coeffs, o.strings)
-        c = o.coeffs[k] / (1im ^ ycount(o.strings[k]))
+        c = o.coeffs[k] / (1im^ycount(o.strings[k]))
         sk = sparse(o.strings[k])
         Ii, Jj, Vv = findnz(sk)
         append!(I, Ii)
@@ -366,14 +364,13 @@ function SparseArrays.sparse(o::Operator)
 end
 
 
-
 """
     Matrix(o::Operator)
 
 Convert an operator to a dense matrix.
 """
 Base.Matrix(o::Operator) = Matrix(SparseArrays.sparse(o))
-Base.Matrix(o::OperatorTS{Ls,Ps,U,T} where {Ls,Ps,U,T<:Number}) = Matrix(resum(o))
+Base.Matrix(o::OperatorTS{Ls, Ps, U, T} where {Ls, Ps, U, T <: Number}) = Matrix(resum(o))
 
 """
     get_coeff(o::Operator{P}, p::P) where {P}
@@ -408,7 +405,6 @@ String macro to create a pauli string.
 p_str(pauli) = PauliString(pauli)
 
 
-
 """
     vw_in_o(v::Unsigned, w::Unsigned, o::Operator)
 
@@ -424,9 +420,8 @@ function vw_in_o(v::Unsigned, w::Unsigned, o::Operator)
 end
 
 
-
 function Base.sort(o::Operator)
-    i = sortperm(eachindex(o.coeffs), by=i -> (abs(o.coeffs[i]), o.strings[i]))
+    i = sortperm(eachindex(o.coeffs), by = i -> (abs(o.coeffs[i]), o.strings[i]))
     o2 = typeof(o)(o.strings[i], o.coeffs[i])
     return o2
 end
@@ -459,11 +454,11 @@ function Operator(M::Matrix)
     @assert ispow2(size(M, 1)) "Matrix size must be a power of 2"
     N = Int(log2(size(M, 1)))
     o = Operator(N)
-    for i in 0:2^N-1
-        for j in 0:2^N-1
+    for i in 0:(2^N - 1)
+        for j in 0:(2^N - 1)
             p = paulistringtype(o)(i, j)
             c = inner(M, sparse(p)) / (2.0^N)
-            if abs(c) > 1e-16
+            if abs(c) > 1.0e-16
                 push!(o.strings, p)
                 push!(o.coeffs, c * (1im)^ycount(p))
             end

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -1,3 +1,5 @@
+
+
 using Base.Iterators
 
 
@@ -8,7 +10,7 @@ using Base.Iterators
 Efficiently compute `trace(o1*o2)`. This is much faster than doing `trace(o1*o2)`.
 If `scale` is not 0, then the result is normalized such that trace(identity)=scale.
 """
-function trace_product(o1::Operator, o2::Operator; scale = 0)
+function trace_product(o1::Operator, o2::Operator; scale=0)
     # operation is symmetric but more efficient if o1 is the largest collection
     (length(o1) < length(o2)) && return trace_product(o2, o1; scale)
 
@@ -39,7 +41,7 @@ function trace_product(o1::Operator, o2::Operator; scale = 0)
     return tr * scale
 end
 
-function trace_product(o1::Operator{<:PauliStringTS}, o2::Operator{<:PauliStringTS}; scale = 0)
+function trace_product(o1::Operator{<:PauliStringTS}, o2::Operator{<:PauliStringTS}; scale=0)
     checklength(o1, o2)
     Ls = qubitsize(o1)
     Ps = periodicflags(o1)
@@ -86,7 +88,7 @@ Efficiently compute `trace(A^k*B^l)`. This is much faster than doing `trace(A^k*
 
 If `scale` is not 0, then the result is normalized such that trace(identity)=scale.
 """
-function trace_product(A::AbstractOperator, k::Int, B::AbstractOperator, l::Int; scale = 0)
+function trace_product(A::AbstractOperator, k::Int, B::AbstractOperator, l::Int; scale=0)
     @assert typeof(A) == typeof(B)
     m = div(k + l, 2)
     n = k + l - m
@@ -100,7 +102,7 @@ function trace_product(A::AbstractOperator, k::Int, B::AbstractOperator, l::Int;
         C = A^k
         D = B^l
     end
-    return trace_product(C, D; scale = scale)
+    return trace_product(C, D; scale=scale)
 end
 
 
@@ -111,11 +113,12 @@ Compute `trace(A*A)`. This is much faster than doing `trace(A*A)`.
 
 If `scale` is not 0, then the result is normalized such that trace(identity)=scale.
 """
-function trace_product(A::Operator; scale = 0)
+function trace_product(A::Operator; scale=0)
     c = get_coeffs(A)
     N = qubitlength(A)
-    return sum(c .^ 2) * (iszero(scale) ? 2.0^N : scale)
+    return sum(c.^2) * (iszero(scale) ? 2.0^N : scale)
 end
+
 
 
 """
@@ -125,7 +128,8 @@ Compute `trace(A*A)`. This is much faster than doing `trace(A*A)`.
 
 If `scale` is not 0, then the result is normalized such that trace(identity)=scale.
 """
-trace_product(A::Operator{<:PauliStringTS}; scale = 0) = trace_product(A, A; scale = scale)
+trace_product(A::Operator{<:PauliStringTS}; scale=0) = trace_product(A, A; scale=scale)
+
 
 
 """
@@ -135,13 +139,13 @@ Efficiently compute `trace(A^k)`. This is much faster than doing `trace(A^k)`.
 
 If `scale` is not 0, then the result is normalized such that trace(identity)=scale.
 """
-function trace_product(A::AbstractOperator, k::Int; scale = 0)
+function trace_product(A::AbstractOperator, k::Int; scale=0)
     m = div(k, 2)
     n = k - m
     C = A^m
-    (k % 2 == 0) && (return trace_product(C; scale = scale))
+    (k%2 == 0) && (return trace_product(C; scale=scale))
     D = A^n
-    return trace_product(C, D; scale = scale)
+    return trace_product(C, D; scale=scale)
 end
 
 """
@@ -150,7 +154,7 @@ end
 Efficiently compute `<0|o1*o2|0>`.
 If `scale` is not 0, then the result is normalized such that `trace(identity) = scale`.
 """
-function trace_product_z(o1::AbstractOperator, o2::AbstractOperator; scale = 0)
+function trace_product_z(o1::AbstractOperator, o2::AbstractOperator; scale=0)
     scale = iszero(scale) ? 2.0^qubitlength(o1) : scale
     tr = zero(scalartype(o1))
 
@@ -177,8 +181,8 @@ start is the first moment to start from.
 
 If scale is not 0, then the result is normalized such that trace(identity)=scale.
 """
-function moments(H::AbstractOperator, kmax::Int; start = 1, scale = 0)
-    return [trace_product(H, k; scale = scale) for k in start:kmax]
+function moments(H::AbstractOperator, kmax::Int; start=1, scale=0)
+    return [trace_product(H, k; scale=scale) for k in start:kmax]
 end
 
 
@@ -186,7 +190,7 @@ end
 # ----------------------------------------------------
 
 
-function trace_product(o::Operator, p::PauliString; scale = 0)
+function trace_product(o::Operator, p::PauliString; scale=0)
     checklength(o, p)
     c = get_coeff(o, p)
     N = qubitlength(o)
@@ -194,13 +198,14 @@ function trace_product(o::Operator, p::PauliString; scale = 0)
     return c * scale
 end
 
-trace_product(p::PauliString, o::Operator; scale = 0) = trace_product(o, p; scale = scale)
+trace_product(p::PauliString, o::Operator; scale=0) = trace_product(o, p; scale=scale)
+
 
 
 # Operations between OperatorTS and PauliStringTS
 # ----------------------------------------------------
 
-function trace_product(o1::Operator{<:PauliStringTS}, o2::PauliStringTS; scale = 0)
+function trace_product(o1::Operator{<:PauliStringTS}, o2::PauliStringTS; scale=0)
     checklength(o1, o2)
     Ls = qubitsize(o1)
     Ps = periodicflags(o1)
@@ -223,13 +228,14 @@ function trace_product(o1::Operator{<:PauliStringTS}, o2::PauliStringTS; scale =
     return tr * scale * num_translations
 end
 
-trace_product(p::PauliStringTS, o::Operator{<:PauliStringTS}; scale = 0) = trace_product(o, p; scale = scale)
+trace_product(p::PauliStringTS, o::Operator{<:PauliStringTS}; scale=0) = trace_product(o, p; scale=scale)
+
 
 
 # Operations between PauliString and PauliString
 # ----------------------------------------------
 
-function trace_product(s1::P, s2::P; scale = 0) where {P <: PauliString}
+function trace_product(s1::P, s2::P; scale=0) where {P<:PauliString}
     N = qubitlength(s1)
     if s1 == s2
         (iszero(scale)) && (scale = 2.0^N)
@@ -239,7 +245,7 @@ function trace_product(s1::P, s2::P; scale = 0) where {P <: PauliString}
     end
 end
 
-function trace_product(s1::P, s2::P; scale = 0) where {P <: PauliStringTS}
+function trace_product(s1::P, s2::P; scale=0) where {P<:PauliStringTS}
     N = qubitlength(s1)
     if s1 == s2
         (scale == 0) && (scale = 2.0^N)

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -1,5 +1,3 @@
-
-
 using Base.Iterators
 
 
@@ -10,9 +8,9 @@ using Base.Iterators
 Efficiently compute `trace(o1*o2)`. This is much faster than doing `trace(o1*o2)`.
 If `scale` is not 0, then the result is normalized such that trace(identity)=scale.
 """
-function trace_product(o1::Operator, o2::Operator; scale=0)
+function trace_product(o1::Operator, o2::Operator; scale = 0)
     # operation is symmetric but more efficient if o1 is the largest collection
-    (length(o1.strings) < length(o2.strings)) && return trace_product(o2, o1; scale)
+    (length(o1) < length(o2)) && return trace_product(o2, o1; scale)
 
     checklength(o1, o2)
     N = qubitlength(o1)
@@ -25,12 +23,11 @@ function trace_product(o1::Operator, o2::Operator; scale=0)
     # trace of product contributes only if product is 1, which only happens when strings are equal
     # this amounts to `indexin`, which we hijack/reimplement here for efficiency
     d = emptydict(o2)
-    @inbounds for i in eachindex(o2.strings)
-        insert!(d, o2.strings[i], o2.coeffs[i])
+    @inbounds for (p, c) in pairs(o2)
+        insert!(d, p, c)
     end
 
-    @inbounds for i in eachindex(o1.strings)
-        p1, c1 = o1.strings[i], o1.coeffs[i]
+    @inbounds for (p1, c1) in pairs(o1)
         c2 = get(d, p1, nothing)
         # TODO: verify if c2 = zero(c1) without branch is faster implementation
         isnothing(c2) && continue
@@ -42,7 +39,7 @@ function trace_product(o1::Operator, o2::Operator; scale=0)
     return tr * scale
 end
 
-function trace_product(o1::Operator{<:PauliStringTS}, o2::Operator{<:PauliStringTS}; scale=0)
+function trace_product(o1::Operator{<:PauliStringTS}, o2::Operator{<:PauliStringTS}; scale = 0)
     checklength(o1, o2)
     Ls = qubitsize(o1)
     Ps = periodicflags(o1)
@@ -50,11 +47,11 @@ function trace_product(o1::Operator{<:PauliStringTS}, o2::Operator{<:PauliString
 
     # see above
     d = emptydict(o2)
-    for (p2, c2) in zip(o2.strings, o2.coeffs)
+    for (p2, c2) in pairs(o2)
         insert!(d, p2, c2)
     end
 
-    for (p1, c1) in zip(o1.strings, o1.coeffs)
+    for (p1, c1) in pairs(o1)
         c2 = get(d, p1, nothing)
         isnothing(c2) && continue
         rep1 = representative(p1)
@@ -89,7 +86,7 @@ Efficiently compute `trace(A^k*B^l)`. This is much faster than doing `trace(A^k*
 
 If `scale` is not 0, then the result is normalized such that trace(identity)=scale.
 """
-function trace_product(A::AbstractOperator, k::Int, B::AbstractOperator, l::Int; scale=0)
+function trace_product(A::AbstractOperator, k::Int, B::AbstractOperator, l::Int; scale = 0)
     @assert typeof(A) == typeof(B)
     m = div(k + l, 2)
     n = k + l - m
@@ -103,7 +100,7 @@ function trace_product(A::AbstractOperator, k::Int, B::AbstractOperator, l::Int;
         C = A^k
         D = B^l
     end
-    return trace_product(C, D; scale=scale)
+    return trace_product(C, D; scale = scale)
 end
 
 
@@ -114,12 +111,11 @@ Compute `trace(A*A)`. This is much faster than doing `trace(A*A)`.
 
 If `scale` is not 0, then the result is normalized such that trace(identity)=scale.
 """
-function trace_product(A::Operator; scale=0)
+function trace_product(A::Operator; scale = 0)
     c = get_coeffs(A)
     N = qubitlength(A)
-    return sum(c.^2) * (iszero(scale) ? 2.0^N : scale)
+    return sum(c .^ 2) * (iszero(scale) ? 2.0^N : scale)
 end
-
 
 
 """
@@ -129,8 +125,7 @@ Compute `trace(A*A)`. This is much faster than doing `trace(A*A)`.
 
 If `scale` is not 0, then the result is normalized such that trace(identity)=scale.
 """
-trace_product(A::Operator{<:PauliStringTS}; scale=0) = trace_product(A, A; scale=scale)
-
+trace_product(A::Operator{<:PauliStringTS}; scale = 0) = trace_product(A, A; scale = scale)
 
 
 """
@@ -140,13 +135,13 @@ Efficiently compute `trace(A^k)`. This is much faster than doing `trace(A^k)`.
 
 If `scale` is not 0, then the result is normalized such that trace(identity)=scale.
 """
-function trace_product(A::AbstractOperator, k::Int; scale=0)
+function trace_product(A::AbstractOperator, k::Int; scale = 0)
     m = div(k, 2)
     n = k - m
     C = A^m
-    (k%2 == 0) && (return trace_product(C; scale=scale))
+    (k % 2 == 0) && (return trace_product(C; scale = scale))
     D = A^n
-    return trace_product(C, D; scale=scale)
+    return trace_product(C, D; scale = scale)
 end
 
 """
@@ -155,7 +150,7 @@ end
 Efficiently compute `<0|o1*o2|0>`.
 If `scale` is not 0, then the result is normalized such that `trace(identity) = scale`.
 """
-function trace_product_z(o1::AbstractOperator, o2::AbstractOperator; scale=0)
+function trace_product_z(o1::AbstractOperator, o2::AbstractOperator; scale = 0)
     scale = iszero(scale) ? 2.0^qubitlength(o1) : scale
     tr = zero(scalartype(o1))
 
@@ -182,8 +177,8 @@ start is the first moment to start from.
 
 If scale is not 0, then the result is normalized such that trace(identity)=scale.
 """
-function moments(H::AbstractOperator, kmax::Int; start=1, scale=0)
-    return [trace_product(H, k; scale=scale) for k in start:kmax]
+function moments(H::AbstractOperator, kmax::Int; start = 1, scale = 0)
+    return [trace_product(H, k; scale = scale) for k in start:kmax]
 end
 
 
@@ -191,7 +186,7 @@ end
 # ----------------------------------------------------
 
 
-function trace_product(o::Operator, p::PauliString; scale=0)
+function trace_product(o::Operator, p::PauliString; scale = 0)
     checklength(o, p)
     c = get_coeff(o, p)
     N = qubitlength(o)
@@ -199,14 +194,13 @@ function trace_product(o::Operator, p::PauliString; scale=0)
     return c * scale
 end
 
-trace_product(p::PauliString, o::Operator; scale=0) = trace_product(o, p; scale=scale)
-
+trace_product(p::PauliString, o::Operator; scale = 0) = trace_product(o, p; scale = scale)
 
 
 # Operations between OperatorTS and PauliStringTS
 # ----------------------------------------------------
 
-function trace_product(o1::Operator{<:PauliStringTS}, o2::PauliStringTS; scale=0)
+function trace_product(o1::Operator{<:PauliStringTS}, o2::PauliStringTS; scale = 0)
     checklength(o1, o2)
     Ls = qubitsize(o1)
     Ps = periodicflags(o1)
@@ -229,14 +223,13 @@ function trace_product(o1::Operator{<:PauliStringTS}, o2::PauliStringTS; scale=0
     return tr * scale * num_translations
 end
 
-trace_product(p::PauliStringTS, o::Operator{<:PauliStringTS}; scale=0) = trace_product(o, p; scale=scale)
-
+trace_product(p::PauliStringTS, o::Operator{<:PauliStringTS}; scale = 0) = trace_product(o, p; scale = scale)
 
 
 # Operations between PauliString and PauliString
 # ----------------------------------------------
 
-function trace_product(s1::P, s2::P; scale=0) where {P<:PauliString}
+function trace_product(s1::P, s2::P; scale = 0) where {P <: PauliString}
     N = qubitlength(s1)
     if s1 == s2
         (iszero(scale)) && (scale = 2.0^N)
@@ -246,7 +239,7 @@ function trace_product(s1::P, s2::P; scale=0) where {P<:PauliString}
     end
 end
 
-function trace_product(s1::P, s2::P; scale=0) where {P<:PauliStringTS}
+function trace_product(s1::P, s2::P; scale = 0) where {P <: PauliStringTS}
     N = qubitlength(s1)
     if s1 == s2
         (scale == 0) && (scale = 2.0^N)

--- a/src/noise.jl
+++ b/src/noise.jl
@@ -1,4 +1,3 @@
-
 """
     add_noise(o::Operator, g::Real)
 
@@ -46,14 +45,15 @@ function add_noise(o::AbstractOperator, g::AbstractVector{<:Real})
 end
 
 
-
 dephasing_weight_z(p::PauliString) = count_ones(p.w)
 dephasing_weight_x(p::PauliString) = count_ones(p.v)
 dephasing_weight_y(p::PauliString) = count_ones(p.v ⊻ p.w)
 
-dephasing_weights = Dict(:Z => dephasing_weight_z,
-                         :X => dephasing_weight_x,
-                         :Y => dephasing_weight_y)
+dephasing_weights = Dict(
+    :Z => dephasing_weight_z,
+    :X => dephasing_weight_x,
+    :Y => dephasing_weight_y
+)
 
 
 """
@@ -68,7 +68,7 @@ either ``X`` or ``Y``.
 # Reference
 [https://arxiv.org/abs/2306.05804](https://arxiv.org/pdf/2306.05804)
 """
-function add_dephasing_noise(o::AbstractOperator, g::Real; basis::Symbol=:Z)
+function add_dephasing_noise(o::AbstractOperator, g::Real; basis::Symbol = :Z)
     dephasing_weight = dephasing_weights[basis]
     o2 = deepcopy(o)
     for i in 1:length(o)
@@ -77,7 +77,6 @@ function add_dephasing_noise(o::AbstractOperator, g::Real; basis::Symbol=:Z)
     end
     return o2
 end
-
 
 
 """

--- a/src/noise.jl
+++ b/src/noise.jl
@@ -1,3 +1,4 @@
+
 """
     add_noise(o::Operator, g::Real)
 
@@ -45,15 +46,14 @@ function add_noise(o::AbstractOperator, g::AbstractVector{<:Real})
 end
 
 
+
 dephasing_weight_z(p::PauliString) = count_ones(p.w)
 dephasing_weight_x(p::PauliString) = count_ones(p.v)
 dephasing_weight_y(p::PauliString) = count_ones(p.v ⊻ p.w)
 
-dephasing_weights = Dict(
-    :Z => dephasing_weight_z,
-    :X => dephasing_weight_x,
-    :Y => dephasing_weight_y
-)
+dephasing_weights = Dict(:Z => dephasing_weight_z,
+                         :X => dephasing_weight_x,
+                         :Y => dephasing_weight_y)
 
 
 """
@@ -68,7 +68,7 @@ either ``X`` or ``Y``.
 # Reference
 [https://arxiv.org/abs/2306.05804](https://arxiv.org/pdf/2306.05804)
 """
-function add_dephasing_noise(o::AbstractOperator, g::Real; basis::Symbol = :Z)
+function add_dephasing_noise(o::AbstractOperator, g::Real; basis::Symbol=:Z)
     dephasing_weight = dephasing_weights[basis]
     o2 = deepcopy(o)
     for i in 1:length(o)
@@ -77,6 +77,7 @@ function add_dephasing_noise(o::AbstractOperator, g::Real; basis::Symbol = :Z)
     end
     return o2
 end
+
 
 
 """

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -170,38 +170,56 @@ Base.:-(o::AbstractOperator, a::Number) = o + (-a * one(o))
 Base.:-(a::Number, o::AbstractOperator) = (a * one(o)) - o
 
 """
-    binary_kernel(f, A::Operator, B::Operator; maxlength::Int=1000)
+    binary_kernel(f, A::AbstractOperator, B::AbstractOperator; maxlength::Int=1000, epsilon::Real=1e-16)
 
-Compute-kernel of applying a function `f` to all pairs of strings in two operators `A` and `B`,
-reducing the result to a new operator.
+Compute-kernel of applying a low-level Pauli function `f` (`prod`, `commutator`,
+`anticommutator`) to all pairs of strings in two operands `A` and `B`, reducing the result to
+a new `Operator`. Each operand may be a single Pauli string or a full operator, iterated
+uniformly through the `keys`/`values` interface.
+
+The two operands must share the same Pauli string type. For translation-symmetric strings the
+product is summed against every lattice shift of the second representative (`all_shifts`); the
+branch on `PauliStringTS` is resolved at compile time, so each variant compiles to a tight,
+fully-inlined loop. Terms with vanishing coefficient or Pauli weight `>= maxlength` are
+dropped, and the result is `cutoff` at `epsilon`.
 """
-function binary_kernel(f, A::Operator, B::Operator; maxlength::Int = 1000)
+function binary_kernel(f, A::AbstractOperator, B::AbstractOperator; maxlength::Int = 1000, epsilon::Real = 1.0e-16)
     checklength(A, B)
 
-    d = emptydict(A) # reducer
-    p1s, c1s = A.strings, A.coeffs
-    p2s, c2s = B.strings, B.coeffs
+    P = paulistringtype(A)
+    T = Base.promote_op(*, scalartype(A), scalartype(B))
+    d = UnorderedDictionary{P, T}(; sizehint = max(length(A), length(B)))
+    ksA, vsA = keys(A), values(A)
+    ksB, vsB = keys(B), values(B)
 
-    # check boundaries to safely use `@inbounds`
-    length(p1s) == length(c1s) || throw(DimensionMismatch("strings and coefficients must have the same length"))
-    length(p2s) == length(c2s) || throw(DimensionMismatch("strings and coefficients must have the same length"))
-
-    # core kernel logic
-    @inbounds for i1 in eachindex(p1s)
-        p1, c1 = p1s[i1], c1s[i1]
-        for i2 in eachindex(p2s)
-            p2, c2 = p2s[i2], c2s[i2]
-            p, k = f(p1, p2)
-            c = c1 * c2 * k
-            if (k != 0) && pauli_weight(p) < maxlength
-                setwith!(+, d, p, c)
+    # core kernel logic; the `P <: PauliStringTS` test is a compile-time constant
+    if P <: PauliStringTS
+        Ls, Ps = qubitsize(P), periodicflags(P)
+        @inbounds for i in eachindex(ksA, vsA)
+            rep1, c1 = representative(ksA[i]), vsA[i]
+            for j in eachindex(ksB, vsB)
+                rep2, c2 = representative(ksB[j]), vsB[j]
+                for s in all_shifts(Ls, Ps)
+                    p, k = f(rep1, shift(rep2, Ls, Ps, s))
+                    (iszero(k) || pauli_weight(p) >= maxlength) && continue
+                    setwith!(+, d, PauliStringTS{Ls, Ps}(p), c1 * c2 * k)
+                end
+            end
+        end
+    else
+        @inbounds for i in eachindex(ksA, vsA)
+            p1, c1 = ksA[i], vsA[i]
+            for j in eachindex(ksB, vsB)
+                p, k = f(p1, ksB[j])
+                (iszero(k) || pauli_weight(p) >= maxlength) && continue
+                setwith!(+, d, p, c1 * vsB[j] * k)
             end
         end
     end
 
     # assemble output
-    o = Operator{keytype(d), valtype(d)}(collect(keys(d)), collect(values(d)))
-    return (eltype(o.coeffs) == ComplexF64) ? cutoff(o, 1.0e-16) : o
+    o = Operator{P, ComplexF64}(collect(keys(d)), collect(values(d)))
+    return cutoff(o, epsilon)
 end
 
 """
@@ -242,7 +260,7 @@ julia> A*5
 (5.0 - 0.0im) XYZ1
 ```
 """
-Base.:*(o1::Operator, o2::Operator; kwargs...) = binary_kernel(prod, o1, o2; kwargs...)
+Base.:*(A::AbstractOperator, B::AbstractOperator; kwargs...) = binary_kernel(prod, A, B; kwargs...)
 
 
 """
@@ -260,7 +278,7 @@ julia> commutator(A,B)
 (0.0 - 2.0im) Y111
 ```
 """
-commutator(o1::Operator, o2::Operator; kwargs...) = binary_kernel(commutator, o1, o2; kwargs...)
+commutator(A::AbstractOperator, B::AbstractOperator; kwargs...) = binary_kernel(commutator, A, B; kwargs...)
 
 
 """
@@ -268,7 +286,7 @@ commutator(o1::Operator, o2::Operator; kwargs...) = binary_kernel(commutator, o1
 
 Commutator of two operators. This is faster than doing `o1*o2 + o2*o1`.
 """
-anticommutator(o1::Operator, o2::Operator; kwargs...) = binary_kernel(anticommutator, o1, o2; kwargs...)
+anticommutator(A::AbstractOperator, B::AbstractOperator; kwargs...) = binary_kernel(anticommutator, A, B; kwargs...)
 
 
 Base.@deprecate com(o1, o2; anti = false, kwargs...) (anti ? anticommutator : commutator)(o1, o2; kwargs...)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,17 +1,17 @@
 # PauliString operations
 # ======================
 
-@inline Base.:(==)(p1::P, p2::P) where {P<:PauliString} = (p1.v == p2.v) & (p1.w == p2.w)
+@inline Base.:(==)(p1::P, p2::P) where {P <: PauliString} = (p1.v == p2.v) & (p1.w == p2.w)
 
 # magic number for the Fibonacci hash function in UInt
 const fib_magic_32 = 0x9e3779b9
 const fib_magic_64 = 0x9e3779b97f4a7c15
-Base.hash(p::PauliString{N,UInt64}, h::UInt) where {N} = hash(muladd(p.v, fib_magic_64, p.w), h)
-Base.hash(p::PauliString{N,UInt32}, h::UInt) where {N} = hash(muladd(p.v, fib_magic_32, p.w), h)
+Base.hash(p::PauliString{N, UInt64}, h::UInt) where {N} = hash(muladd(p.v, fib_magic_64, p.w), h)
+Base.hash(p::PauliString{N, UInt32}, h::UInt) where {N} = hash(muladd(p.v, fib_magic_32, p.w), h)
 Base.hash(p::PauliString, h::UInt) = hash((p.v, p.w), h)
 
 # assuming that short-circuited evaluation is slower than bitwise operations
-Base.isless(p1::P, p2::P) where {P<:PauliString} = (p1.v < p2.v) | ((p1.v == p2.v) & (p1.w < p2.w))
+Base.isless(p1::P, p2::P) where {P <: PauliString} = (p1.v < p2.v) | ((p1.v == p2.v) & (p1.w < p2.w))
 
 # unary operations
 # ----------------
@@ -45,30 +45,28 @@ pauli_weight(p::PauliString) = count_ones(p.v | p.w)
 
 # binary operations
 # -----------------
-Base.xor(p1::P, p2::P) where {P<:PauliString} = P(p1.v ⊻ p2.v, p1.w ⊻ p2.w)
+Base.xor(p1::P, p2::P) where {P <: PauliString} = P(p1.v ⊻ p2.v, p1.w ⊻ p2.w)
 
-function commutator(p1::P, p2::P) where {P<:PauliString}
+function commutator(p1::P, p2::P) where {P <: PauliString}
     p = p1 ⊻ p2
     k = ((count_ones(p2.v & p1.w) & 1) << 1) - ((count_ones(p1.v & p2.w) & 1) << 1)
     return p, k
 end
 
-function anticommutator(p1::P, p2::P) where {P<:PauliString}
+function anticommutator(p1::P, p2::P) where {P <: PauliString}
     p = p1 ⊻ p2
     k = 2 - (((count_ones(p1.v & p2.w) & 1) << 1) + ((count_ones(p1.w & p2.v) & 1) << 1))
     return p, k
 end
 
-function prod(p1::P, p2::P) where {P<:PauliString}
+function prod(p1::P, p2::P) where {P <: PauliString}
     p = p1 ⊻ p2
     k = 1 - ((count_ones(p1.v & p2.w) & 1) << 1)
     return p, k
 end
 
 
-
-emptydict(o::AbstractOperator) = UnorderedDictionary{eltype(o.strings),eltype(o.coeffs)}()
-
+emptydict(o::AbstractOperator) = UnorderedDictionary{eltype(o.strings), eltype(o.coeffs)}()
 
 
 """
@@ -109,7 +107,7 @@ julia> A+5
 (5.0 + 0.0im) 1111
 ```
 """
-function Base.:+(o1::O, o2::O) where {O<:AbstractOperator}
+function Base.:+(o1::O, o2::O) where {O <: AbstractOperator}
     checklength(o1, o2)
 
     d = emptydict(o1)
@@ -129,7 +127,7 @@ function Base.:+(o1::O, o2::O) where {O<:AbstractOperator}
 
     # assemble output
     o3 = typeof(o1)(collect(keys(d)), collect(values(d)))
-    return (eltype(o3.coeffs) == ComplexF64) ? cutoff(o3, 1e-16) : o3
+    return (eltype(o3.coeffs) == ComplexF64) ? cutoff(o3, 1.0e-16) : o3
 end
 
 
@@ -141,7 +139,7 @@ end
     Base.:-(o1::Operator, o2::Operator)
 Subtraction between operators and numbers
 """
-function Base.:-(o1::O, o2::O) where {O<:AbstractOperator}
+function Base.:-(o1::O, o2::O) where {O <: AbstractOperator}
     checklength(o1, o2)
 
     d = emptydict(o1)
@@ -161,7 +159,7 @@ function Base.:-(o1::O, o2::O) where {O<:AbstractOperator}
 
     # assemble output
     o3 = typeof(o1)(collect(keys(d)), collect(values(d)))
-    return (eltype(o3.coeffs) == ComplexF64) ? cutoff(o3, 1e-16) : o3
+    return (eltype(o3.coeffs) == ComplexF64) ? cutoff(o3, 1.0e-16) : o3
 end
 
 Base.:+(o::AbstractOperator, a::Number) = o + a * one(o)
@@ -177,7 +175,7 @@ Base.:-(a::Number, o::AbstractOperator) = (a * one(o)) - o
 Compute-kernel of applying a function `f` to all pairs of strings in two operators `A` and `B`,
 reducing the result to a new operator.
 """
-function binary_kernel(f, A::Operator, B::Operator; maxlength::Int=1000)
+function binary_kernel(f, A::Operator, B::Operator; maxlength::Int = 1000)
     checklength(A, B)
 
     d = emptydict(A) # reducer
@@ -202,8 +200,8 @@ function binary_kernel(f, A::Operator, B::Operator; maxlength::Int=1000)
     end
 
     # assemble output
-    o = Operator{keytype(d),valtype(d)}(collect(keys(d)), collect(values(d)))
-    return (eltype(o.coeffs) == ComplexF64) ? cutoff(o, 1e-16) : o
+    o = Operator{keytype(d), valtype(d)}(collect(keys(d)), collect(values(d)))
+    return (eltype(o.coeffs) == ComplexF64) ? cutoff(o, 1.0e-16) : o
 end
 
 """
@@ -273,7 +271,7 @@ Commutator of two operators. This is faster than doing `o1*o2 + o2*o1`.
 anticommutator(o1::Operator, o2::Operator; kwargs...) = binary_kernel(anticommutator, o1, o2; kwargs...)
 
 
-Base.@deprecate com(o1, o2; anti=false, kwargs...) (anti ? anticommutator : commutator)(o1, o2; kwargs...)
+Base.@deprecate com(o1, o2; anti = false, kwargs...) (anti ? anticommutator : commutator)(o1, o2; kwargs...)
 
 commutator(o1::Operator, o2::Number; kwargs...) = 0
 anticommutator(o1::Operator, o2::Number; kwargs...) = 2 * o1 * o2
@@ -311,10 +309,8 @@ Accumulate repeated terms
 """
 function compress(o::AbstractOperator)
     d = emptydict(o)
-    ps, cs = o.strings, o.coeffs
-    length(ps) == length(cs) || throw(DimensionMismatch("strings and coefficients must have the same length"))
-    @inbounds for i in eachindex(ps)
-        setwith!(+, d, ps[i], cs[i])
+    for (p, c) in pairs(o)
+        setwith!(+, d, p, c)
     end
     return typeof(o)(collect(keys(d)), collect(values(d)))
 end
@@ -334,11 +330,11 @@ julia> trace(A)
 32.0 + 0.0im
 ```
 """
-function trace(o::Operator; normalize=false)
+function trace(o::Operator; normalize = false)
     t = zero(scalartype(o))
-    for i in 1:length(o)
-        if isone(o.strings[i])
-            t += o.coeffs[i]
+    for (p, c) in pairs(o)
+        if isone(p)
+            t += c
         end
     end
     if normalize
@@ -349,7 +345,7 @@ function trace(o::Operator; normalize=false)
 end
 
 
-LinearAlgebra.tr(o::AbstractOperator; normalize=false) = trace(o; normalize=normalize)
+LinearAlgebra.tr(o::AbstractOperator; normalize = false) = trace(o; normalize = normalize)
 
 
 """
@@ -370,11 +366,18 @@ julia> diag(A)
 ```
 """
 function LinearAlgebra.diag(o::AbstractOperator)
-    I = findall(p -> xcount(p) == 0 && ycount(p) == 0, o.strings)
-    return typeof(o)(o.strings[I], o.coeffs[I])
+    ks = paulistringtype(o)[]
+    vs = scalartype(o)[]
+    for (p, c) in pairs(o)
+        if xcount(p) == 0 && ycount(p) == 0
+            push!(ks, p)
+            push!(vs, c)
+        end
+    end
+    return typeof(o)(ks, vs)
 end
 
-Base.@deprecate opnorm(o::AbstractOperator; normalize=false) LinearAlgebra.norm(o; normalize=normalize)
+Base.@deprecate opnorm(o::AbstractOperator; normalize = false) LinearAlgebra.norm(o; normalize = normalize)
 
 """
     LinearAlgebra.norm(o::AbstractOperator; normalize=false)
@@ -390,8 +393,9 @@ julia> norm(A)
 8.94427190999916
 ```
 """
-function LinearAlgebra.norm(o::AbstractOperator; normalize=false)
-    normalize ? norm(o.coeffs) : norm(o.coeffs) * (2.0^(qubitlength(o) / 2))
+function LinearAlgebra.norm(o::AbstractOperator; normalize = false)
+    n = norm(values(o))
+    return normalize ? n : n * (2.0^(qubitlength(o) / 2))
 end
 
 
@@ -423,17 +427,18 @@ julia> A'
 ```
 """
 function Base.adjoint(o::AbstractOperator)
-    o1 = deepcopy(o)
-    for i in 1:length(o1)
-        p = o1.strings[i]
+    L = length(o)
+    ks = Vector{paulistringtype(o)}(undef, L)
+    vs = Vector{scalartype(o)}(undef, L)
+    @inbounds for (i, (p, c)) in enumerate(pairs(o))
+        ks[i] = p
         s = 1 - ((ycount(p) & 1) << 1)
-        o1.coeffs[i] = s * conj(o1.coeffs[i])
+        vs[i] = s * conj(c)
     end
-    return o1
+    return typeof(o)(ks, vs)
 end
 
 Base.@deprecate dagger(o) Base.adjoint(o::AbstractOperator)
-
 
 
 """
@@ -479,13 +484,15 @@ function ptrace(o::AbstractOperator, keep::Vector{Int})
     o2 = typeof(o)()
     NA = length(keep)
     NB = qubitlength(o) - NA
-    for i in 1:length(o)
-        if tokeep(o.strings[i], keep)
-            push!(o2.strings, o.strings[i])
-            push!(o2.coeffs, o.coeffs[i])
+    c_id = zero(scalartype(o))
+    for (p, c) in pairs(o)
+        if tokeep(p, keep)
+            push!(o2.strings, p)
+            push!(o2.coeffs, c)
         else
-            o2 += o.coeffs[i] * 2^NB / (1im)^ycount(o.strings[i])
+            c_id += c * 2^NB / (1im)^ycount(p)
         end
     end
+    o2 += c_id
     return o2
 end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -187,7 +187,7 @@ function binary_kernel(f, A::AbstractOperator, B::AbstractOperator; maxlength::I
     checklength(A, B)
 
     P = paulistringtype(A)
-    T = Base.promote_op(*, scalartype(A), scalartype(B))
+    T = complex(Base.promote_op(*, scalartype(A), scalartype(B)))
     d = UnorderedDictionary{P, T}(; sizehint = max(length(A), length(B)))
     ksA, vsA = keys(A), values(A)
     ksB, vsB = keys(B), values(B)
@@ -218,7 +218,7 @@ function binary_kernel(f, A::AbstractOperator, B::AbstractOperator; maxlength::I
     end
 
     # assemble output
-    o = Operator{P, ComplexF64}(collect(keys(d)), collect(values(d)))
+    o = Operator{P, T}(collect(keys(d)), collect(values(d)))
     return cutoff(o, epsilon)
 end
 

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,17 +1,17 @@
 # PauliString operations
 # ======================
 
-@inline Base.:(==)(p1::P, p2::P) where {P <: PauliString} = (p1.v == p2.v) & (p1.w == p2.w)
+@inline Base.:(==)(p1::P, p2::P) where {P<:PauliString} = (p1.v == p2.v) & (p1.w == p2.w)
 
 # magic number for the Fibonacci hash function in UInt
 const fib_magic_32 = 0x9e3779b9
 const fib_magic_64 = 0x9e3779b97f4a7c15
-Base.hash(p::PauliString{N, UInt64}, h::UInt) where {N} = hash(muladd(p.v, fib_magic_64, p.w), h)
-Base.hash(p::PauliString{N, UInt32}, h::UInt) where {N} = hash(muladd(p.v, fib_magic_32, p.w), h)
+Base.hash(p::PauliString{N,UInt64}, h::UInt) where {N} = hash(muladd(p.v, fib_magic_64, p.w), h)
+Base.hash(p::PauliString{N,UInt32}, h::UInt) where {N} = hash(muladd(p.v, fib_magic_32, p.w), h)
 Base.hash(p::PauliString, h::UInt) = hash((p.v, p.w), h)
 
 # assuming that short-circuited evaluation is slower than bitwise operations
-Base.isless(p1::P, p2::P) where {P <: PauliString} = (p1.v < p2.v) | ((p1.v == p2.v) & (p1.w < p2.w))
+Base.isless(p1::P, p2::P) where {P<:PauliString} = (p1.v < p2.v) | ((p1.v == p2.v) & (p1.w < p2.w))
 
 # unary operations
 # ----------------
@@ -45,28 +45,30 @@ pauli_weight(p::PauliString) = count_ones(p.v | p.w)
 
 # binary operations
 # -----------------
-Base.xor(p1::P, p2::P) where {P <: PauliString} = P(p1.v ⊻ p2.v, p1.w ⊻ p2.w)
+Base.xor(p1::P, p2::P) where {P<:PauliString} = P(p1.v ⊻ p2.v, p1.w ⊻ p2.w)
 
-function commutator(p1::P, p2::P) where {P <: PauliString}
+function commutator(p1::P, p2::P) where {P<:PauliString}
     p = p1 ⊻ p2
     k = ((count_ones(p2.v & p1.w) & 1) << 1) - ((count_ones(p1.v & p2.w) & 1) << 1)
     return p, k
 end
 
-function anticommutator(p1::P, p2::P) where {P <: PauliString}
+function anticommutator(p1::P, p2::P) where {P<:PauliString}
     p = p1 ⊻ p2
     k = 2 - (((count_ones(p1.v & p2.w) & 1) << 1) + ((count_ones(p1.w & p2.v) & 1) << 1))
     return p, k
 end
 
-function prod(p1::P, p2::P) where {P <: PauliString}
+function prod(p1::P, p2::P) where {P<:PauliString}
     p = p1 ⊻ p2
     k = 1 - ((count_ones(p1.v & p2.w) & 1) << 1)
     return p, k
 end
 
 
-emptydict(o::AbstractOperator) = UnorderedDictionary{eltype(o.strings), eltype(o.coeffs)}()
+
+emptydict(o::AbstractOperator) = UnorderedDictionary{eltype(o.strings),eltype(o.coeffs)}()
+
 
 
 """
@@ -107,7 +109,7 @@ julia> A+5
 (5.0 + 0.0im) 1111
 ```
 """
-function Base.:+(o1::O, o2::O) where {O <: AbstractOperator}
+function Base.:+(o1::O, o2::O) where {O<:AbstractOperator}
     checklength(o1, o2)
 
     d = emptydict(o1)
@@ -127,7 +129,7 @@ function Base.:+(o1::O, o2::O) where {O <: AbstractOperator}
 
     # assemble output
     o3 = typeof(o1)(collect(keys(d)), collect(values(d)))
-    return (eltype(o3.coeffs) == ComplexF64) ? cutoff(o3, 1.0e-16) : o3
+    return (eltype(o3.coeffs) == ComplexF64) ? cutoff(o3, 1e-16) : o3
 end
 
 
@@ -139,7 +141,7 @@ end
     Base.:-(o1::Operator, o2::Operator)
 Subtraction between operators and numbers
 """
-function Base.:-(o1::O, o2::O) where {O <: AbstractOperator}
+function Base.:-(o1::O, o2::O) where {O<:AbstractOperator}
     checklength(o1, o2)
 
     d = emptydict(o1)
@@ -159,7 +161,7 @@ function Base.:-(o1::O, o2::O) where {O <: AbstractOperator}
 
     # assemble output
     o3 = typeof(o1)(collect(keys(d)), collect(values(d)))
-    return (eltype(o3.coeffs) == ComplexF64) ? cutoff(o3, 1.0e-16) : o3
+    return (eltype(o3.coeffs) == ComplexF64) ? cutoff(o3, 1e-16) : o3
 end
 
 Base.:+(o::AbstractOperator, a::Number) = o + a * one(o)
@@ -183,12 +185,12 @@ branch on `PauliStringTS` is resolved at compile time, so each variant compiles 
 fully-inlined loop. Terms with vanishing coefficient or Pauli weight `>= maxlength` are
 dropped, and the result is `cutoff` at `epsilon`.
 """
-function binary_kernel(f, A::AbstractOperator, B::AbstractOperator; maxlength::Int = 1000, epsilon::Real = 1.0e-16)
+function binary_kernel(f, A::AbstractOperator, B::AbstractOperator; maxlength::Int=1000, epsilon::Real=1e-16)
     checklength(A, B)
 
     P = paulistringtype(A)
     T = complex(Base.promote_op(*, scalartype(A), scalartype(B)))
-    d = UnorderedDictionary{P, T}(; sizehint = max(length(A), length(B)))
+    d = UnorderedDictionary{P,T}(; sizehint=max(length(A), length(B)))
     ksA, vsA = keys(A), values(A)
     ksB, vsB = keys(B), values(B)
 
@@ -202,7 +204,7 @@ function binary_kernel(f, A::AbstractOperator, B::AbstractOperator; maxlength::I
                 for s in all_shifts(Ls, Ps)
                     p, k = f(rep1, shift(rep2, Ls, Ps, s))
                     (iszero(k) || pauli_weight(p) >= maxlength) && continue
-                    setwith!(+, d, PauliStringTS{Ls, Ps}(p), c1 * c2 * k)
+                    setwith!(+, d, PauliStringTS{Ls,Ps}(p), c1 * c2 * k)
                 end
             end
         end
@@ -218,7 +220,7 @@ function binary_kernel(f, A::AbstractOperator, B::AbstractOperator; maxlength::I
     end
 
     # assemble output
-    o = Operator{P, T}(collect(keys(d)), collect(values(d)))
+    o = Operator{P,T}(collect(keys(d)), collect(values(d)))
     return cutoff(o, epsilon)
 end
 
@@ -289,7 +291,7 @@ Commutator of two operators. This is faster than doing `o1*o2 + o2*o1`.
 anticommutator(A::AbstractOperator, B::AbstractOperator; kwargs...) = binary_kernel(anticommutator, A, B; kwargs...)
 
 
-Base.@deprecate com(o1, o2; anti = false, kwargs...) (anti ? anticommutator : commutator)(o1, o2; kwargs...)
+Base.@deprecate com(o1, o2; anti=false, kwargs...) (anti ? anticommutator : commutator)(o1, o2; kwargs...)
 
 commutator(o1::Operator, o2::Number; kwargs...) = 0
 anticommutator(o1::Operator, o2::Number; kwargs...) = 2 * o1 * o2
@@ -348,7 +350,7 @@ julia> trace(A)
 32.0 + 0.0im
 ```
 """
-function trace(o::Operator; normalize = false)
+function trace(o::Operator; normalize=false)
     t = zero(scalartype(o))
     for (p, c) in pairs(o)
         if isone(p)
@@ -363,7 +365,7 @@ function trace(o::Operator; normalize = false)
 end
 
 
-LinearAlgebra.tr(o::AbstractOperator; normalize = false) = trace(o; normalize = normalize)
+LinearAlgebra.tr(o::AbstractOperator; normalize=false) = trace(o; normalize=normalize)
 
 
 """
@@ -395,7 +397,7 @@ function LinearAlgebra.diag(o::AbstractOperator)
     return typeof(o)(ks, vs)
 end
 
-Base.@deprecate opnorm(o::AbstractOperator; normalize = false) LinearAlgebra.norm(o; normalize = normalize)
+Base.@deprecate opnorm(o::AbstractOperator; normalize=false) LinearAlgebra.norm(o; normalize=normalize)
 
 """
     LinearAlgebra.norm(o::AbstractOperator; normalize=false)
@@ -411,7 +413,7 @@ julia> norm(A)
 8.94427190999916
 ```
 """
-function LinearAlgebra.norm(o::AbstractOperator; normalize = false)
+function LinearAlgebra.norm(o::AbstractOperator; normalize=false)
     n = norm(values(o))
     return normalize ? n : n * (2.0^(qubitlength(o) / 2))
 end
@@ -457,6 +459,7 @@ function Base.adjoint(o::AbstractOperator)
 end
 
 Base.@deprecate dagger(o) Base.adjoint(o::AbstractOperator)
+
 
 
 """

--- a/src/operations_strings.jl
+++ b/src/operations_strings.jl
@@ -5,7 +5,7 @@
 # Operations between Operator and PauliString
 # ----------------------------------------------------
 
-function add(o::AbstractOperator, s::AbstractPauliString; sign = 1)
+function add(o::AbstractOperator, s::AbstractPauliString; sign=1)
     o2 = copy(o)
     c = sign * (1im)^ycount(s)
     if s in o2.strings
@@ -18,8 +18,8 @@ function add(o::AbstractOperator, s::AbstractPauliString; sign = 1)
     return o2
 end
 
-Base.:+(o::AbstractOperator, s::AbstractPauliString) = add(o, s; sign = 1)
-Base.:-(o::AbstractOperator, s::AbstractPauliString) = add(o, s; sign = -1)
+Base.:+(o::AbstractOperator, s::AbstractPauliString) = add(o, s; sign=1)
+Base.:-(o::AbstractOperator, s::AbstractPauliString) = add(o, s; sign=-1)
 Base.:+(s::AbstractPauliString, o::AbstractOperator) = o + s
 Base.:-(s::AbstractPauliString, o::AbstractOperator) = o - s
 
@@ -27,8 +27,8 @@ Base.:-(s::AbstractPauliString, o::AbstractOperator) = o - s
 # Operations between PauliString and PauliString
 # ----------------------------------------------------
 
-Base.:+(s1::T, s2::T) where {T <: PauliString} = Operator(qubitlength(s1)) + s1 + s2
-Base.:-(s1::T, s2::T) where {T <: PauliString} = Operator(qubitlength(s1)) + s1 - s2
+Base.:+(s1::T, s2::T) where {T<:PauliString} = Operator(qubitlength(s1)) + s1 + s2
+Base.:-(s1::T, s2::T) where {T<:PauliString} = Operator(qubitlength(s1)) + s1 - s2
 
 """
     Base.cis(p::PauliString)
@@ -76,21 +76,21 @@ returns the 2-branching combination `cos(theta) P + sin(theta) P′` as an
 """
 function pauli_rotation(G::PauliString, P::PauliString, theta::Real)
     stheta, ctheta = sincos(theta)
-    C, k = commutator(G, P)
+    C,k = commutator(G, P)
     if k == 0                   # commuting case
         return Operator(P)
     end
     c1 = (1.0im)^ycount(G)
     c2 = (1.0im)^ycount(P)
-    return Operator([P, C], [ctheta * c2, (1im * stheta / 2) * k * c1 * c2])
+    return Operator([P, C], [ctheta*c2, (1im * stheta / 2) * k*c1*c2])
 end
 
 
 # Operations between PauliStringTS and PauliStringTS
 # ----------------------------------------------------
 
-Base.:+(s1::T, s2::T) where {T <: PauliStringTS} = OperatorTS(s1) + s2
-Base.:-(s1::T, s2::T) where {T <: PauliStringTS} = OperatorTS(s1) - s2
+Base.:+(s1::T, s2::T) where {T<:PauliStringTS} = OperatorTS(s1) + s2
+Base.:-(s1::T, s2::T) where {T<:PauliStringTS} = OperatorTS(s1) - s2
 
 
 # Operations between PauliString and scalar

--- a/src/operations_strings.jl
+++ b/src/operations_strings.jl
@@ -23,44 +23,10 @@ Base.:-(o::AbstractOperator, s::AbstractPauliString) = add(o, s; sign = -1)
 Base.:+(s::AbstractPauliString, o::AbstractOperator) = o + s
 Base.:-(s::AbstractPauliString, o::AbstractOperator) = o - s
 
-function binary_kernel(f, A::Operator, B::PauliString)
-    # checklength(A, B)
-    d = emptydict(A) # reducer
-    p1s, c1s = A.strings, A.coeffs
-    # check boundaries to safely use `@inbounds`
-    length(p1s) == length(c1s) || throw(DimensionMismatch("strings and coefficients must have the same length"))
-    # core kernel logic
-    p2 = B
-    c2 = (1im)^ycount(p2)
-    strings = Vector{typeof(B)}(undef, length(p1s))
-    coeffs = Vector{eltype(c1s)}(undef, length(c1s))
-    @inbounds for i in eachindex(p1s)
-        p1, c1 = p1s[i], c1s[i]
-        p, k = f(p1, p2)
-        c = c1 * c2 * k
-        strings[i] = p
-        coeffs[i] = c
-    end
-    # assemble output
-    o = typeof(A)(strings, coeffs)
-    return (eltype(o.coeffs) == ComplexF64) ? cutoff(o, 1.0e-16) : o
-end
-
-Base.:*(o1::Operator, o2::PauliString) = binary_kernel(prod, o1, o2)
-Base.:*(o2::PauliString, o1::Operator) = (o1' * o2)'
-commutator(o1::Operator, o2::PauliString) = binary_kernel(commutator, o1, o2)
-commutator(o2::PauliString, o1::Operator) = -commutator(o1, o2)
-anticommutator(o1::Operator, o2::PauliString) = binary_kernel(anticommutator, o1, o2)
-anticommutator(o2::PauliString, o1::Operator) = anticommutator(o1, o2)
-
 
 # Operations between PauliString and PauliString
 # ----------------------------------------------------
 
-# function Base.:*(s1::T, s2::T) where {T<:PauliString}
-#     p, k = prod(s1, s2)
-#     return Operator([p], [k])
-# end
 Base.:+(s1::T, s2::T) where {T <: PauliString} = Operator(qubitlength(s1)) + s1 + s2
 Base.:-(s1::T, s2::T) where {T <: PauliString} = Operator(qubitlength(s1)) + s1 - s2
 
@@ -120,81 +86,11 @@ function pauli_rotation(G::PauliString, P::PauliString, theta::Real)
 end
 
 
-# Operations between OperatorTS and PauliStringTS
-# ----------------------------------------------------
-
-function binary_kernel(op, A::Operator{<:PauliStringTS}, B::PauliStringTS; maxlength = 1000, epsilon = 1.0e-16)
-    # checklength(A, B)
-    Ls = qubitsize(A)
-    Ps = periodicflags(A)
-
-    d = emptydict(A)
-    p1s, c1s = A.strings, A.coeffs
-    p2 = B
-    c2 = (1im)^ycount(p2)
-
-    # check lengths to safely use `@inbounds`
-    length(p1s) == length(c1s) || throw(DimensionMismatch("strings and coefficients must have the same length"))
-
-    # core kernel logic
-    @inbounds for (p1, c1) in pairs(A)
-        rep1 = representative(p1)
-        rep2 = representative(p2)
-        for s in all_shifts(paulistringtype(A))
-            p, k = op(rep1, shift(rep2, Ls, Ps, s))
-            c = c1 * c2 * k
-            if (k != 0) && (abs(c) > epsilon) && pauli_weight(p) < maxlength
-                setwith!(+, d, PauliStringTS{Ls, Ps}(p), c)
-            end
-        end
-    end
-
-    o = typeof(A)(collect(keys(d)), collect(values(d)))
-    return (eltype(o.coeffs) == ComplexF64) ? cutoff(o, epsilon) : o
-end
-
-Base.:*(o1::Operator{<:PauliStringTS}, o2::PauliStringTS) = binary_kernel(prod, o1, o2)
-Base.:*(o2::PauliStringTS, o1::Operator{<:PauliStringTS}) = (o1' * o2)'
-commutator(o1::Operator{<:PauliStringTS}, o2::PauliStringTS) = binary_kernel(commutator, o1, o2)
-commutator(o2::PauliStringTS, o1::Operator{<:PauliStringTS}) = -commutator(o1, o2)
-anticommutator(o1::Operator{<:PauliStringTS}, o2::PauliStringTS) = binary_kernel(anticommutator, o1, o2)
-anticommutator(o2::PauliStringTS, o1::Operator{<:PauliStringTS}) = anticommutator(o1, o2)
-
-
 # Operations between PauliStringTS and PauliStringTS
 # ----------------------------------------------------
 
 Base.:+(s1::T, s2::T) where {T <: PauliStringTS} = OperatorTS(s1) + s2
 Base.:-(s1::T, s2::T) where {T <: PauliStringTS} = OperatorTS(s1) - s2
-
-emptydict(pauli::PauliStringTS) = UnorderedDictionary{typeof(pauli), ComplexF64}()
-
-function binary_kernel(op, A::PauliStringTS, B::PauliStringTS; maxlength = 1000, epsilon = 1.0e-16)
-    # checklength(A, B)
-    Ls = qubitsize(A)
-    Ps = periodicflags(A)
-    d = emptydict(A)
-    p1 = A
-    c1 = (1im)^ycount(p1)
-    p2 = B
-    c2 = (1im)^ycount(p2)
-    # core kernel logic
-    rep1 = representative(p1)
-    rep2 = representative(p2)
-    for s in all_shifts(paulistringtype(A))
-        p, k = op(rep1, shift(rep2, Ls, Ps, s))
-        c = c1 * c2 * k
-        if (k != 0) && (abs(c) > epsilon) && pauli_weight(p) < maxlength
-            setwith!(+, d, PauliStringTS{Ls, Ps}(p), c)
-        end
-    end
-    o = Operator{typeof(A), ComplexF64}(collect(keys(d)), collect(values(d)))
-    return (eltype(o.coeffs) == ComplexF64) ? cutoff(o, epsilon) : o
-end
-
-Base.:*(s1::PauliStringTS, s2::PauliStringTS) = binary_kernel(prod, s1, s2)
-commutator(s1::PauliStringTS, s2::PauliStringTS) = binary_kernel(commutator, s1, s2)
-anticommutator(s1::PauliStringTS, s2::PauliStringTS) = binary_kernel(anticommutator, s1, s2)
 
 
 # Operations between PauliString and scalar

--- a/src/operations_strings.jl
+++ b/src/operations_strings.jl
@@ -5,7 +5,7 @@
 # Operations between Operator and PauliString
 # ----------------------------------------------------
 
-function add(o::AbstractOperator, s::AbstractPauliString; sign=1)
+function add(o::AbstractOperator, s::AbstractPauliString; sign = 1)
     o2 = copy(o)
     c = sign * (1im)^ycount(s)
     if s in o2.strings
@@ -18,8 +18,8 @@ function add(o::AbstractOperator, s::AbstractPauliString; sign=1)
     return o2
 end
 
-Base.:+(o::AbstractOperator, s::AbstractPauliString) = add(o, s; sign=1)
-Base.:-(o::AbstractOperator, s::AbstractPauliString) = add(o, s; sign=-1)
+Base.:+(o::AbstractOperator, s::AbstractPauliString) = add(o, s; sign = 1)
+Base.:-(o::AbstractOperator, s::AbstractPauliString) = add(o, s; sign = -1)
 Base.:+(s::AbstractPauliString, o::AbstractOperator) = o + s
 Base.:-(s::AbstractPauliString, o::AbstractOperator) = o - s
 
@@ -43,7 +43,7 @@ function binary_kernel(f, A::Operator, B::PauliString)
     end
     # assemble output
     o = typeof(A)(strings, coeffs)
-    return (eltype(o.coeffs) == ComplexF64) ? cutoff(o, 1e-16) : o
+    return (eltype(o.coeffs) == ComplexF64) ? cutoff(o, 1.0e-16) : o
 end
 
 Base.:*(o1::Operator, o2::PauliString) = binary_kernel(prod, o1, o2)
@@ -54,7 +54,6 @@ anticommutator(o1::Operator, o2::PauliString) = binary_kernel(anticommutator, o1
 anticommutator(o2::PauliString, o1::Operator) = anticommutator(o1, o2)
 
 
-
 # Operations between PauliString and PauliString
 # ----------------------------------------------------
 
@@ -62,8 +61,8 @@ anticommutator(o2::PauliString, o1::Operator) = anticommutator(o1, o2)
 #     p, k = prod(s1, s2)
 #     return Operator([p], [k])
 # end
-Base.:+(s1::T, s2::T) where {T<:PauliString} = Operator(qubitlength(s1)) + s1 + s2
-Base.:-(s1::T, s2::T) where {T<:PauliString} = Operator(qubitlength(s1)) + s1 - s2
+Base.:+(s1::T, s2::T) where {T <: PauliString} = Operator(qubitlength(s1)) + s1 + s2
+Base.:-(s1::T, s2::T) where {T <: PauliString} = Operator(qubitlength(s1)) + s1 - s2
 
 """
     Base.cis(p::PauliString)
@@ -111,20 +110,20 @@ returns the 2-branching combination `cos(theta) P + sin(theta) P′` as an
 """
 function pauli_rotation(G::PauliString, P::PauliString, theta::Real)
     stheta, ctheta = sincos(theta)
-    C,k = commutator(G, P)
+    C, k = commutator(G, P)
     if k == 0                   # commuting case
         return Operator(P)
     end
     c1 = (1.0im)^ycount(G)
     c2 = (1.0im)^ycount(P)
-    return Operator([P, C], [ctheta*c2, (1im * stheta / 2) * k*c1*c2])
+    return Operator([P, C], [ctheta * c2, (1im * stheta / 2) * k * c1 * c2])
 end
 
 
 # Operations between OperatorTS and PauliStringTS
 # ----------------------------------------------------
 
-function binary_kernel(op, A::Operator{<:PauliStringTS}, B::PauliStringTS; maxlength=1000, epsilon=1e-16)
+function binary_kernel(op, A::Operator{<:PauliStringTS}, B::PauliStringTS; maxlength = 1000, epsilon = 1.0e-16)
     # checklength(A, B)
     Ls = qubitsize(A)
     Ps = periodicflags(A)
@@ -138,14 +137,14 @@ function binary_kernel(op, A::Operator{<:PauliStringTS}, B::PauliStringTS; maxle
     length(p1s) == length(c1s) || throw(DimensionMismatch("strings and coefficients must have the same length"))
 
     # core kernel logic
-    @inbounds for (p1, c1) in zip(p1s, c1s)
+    @inbounds for (p1, c1) in pairs(A)
         rep1 = representative(p1)
         rep2 = representative(p2)
         for s in all_shifts(paulistringtype(A))
             p, k = op(rep1, shift(rep2, Ls, Ps, s))
             c = c1 * c2 * k
             if (k != 0) && (abs(c) > epsilon) && pauli_weight(p) < maxlength
-                setwith!(+, d, PauliStringTS{Ls,Ps}(p), c)
+                setwith!(+, d, PauliStringTS{Ls, Ps}(p), c)
             end
         end
     end
@@ -162,17 +161,15 @@ anticommutator(o1::Operator{<:PauliStringTS}, o2::PauliStringTS) = binary_kernel
 anticommutator(o2::PauliStringTS, o1::Operator{<:PauliStringTS}) = anticommutator(o1, o2)
 
 
-
-
 # Operations between PauliStringTS and PauliStringTS
 # ----------------------------------------------------
 
-Base.:+(s1::T, s2::T) where {T<:PauliStringTS} = OperatorTS(s1) + s2
-Base.:-(s1::T, s2::T) where {T<:PauliStringTS} = OperatorTS(s1) - s2
+Base.:+(s1::T, s2::T) where {T <: PauliStringTS} = OperatorTS(s1) + s2
+Base.:-(s1::T, s2::T) where {T <: PauliStringTS} = OperatorTS(s1) - s2
 
-emptydict(pauli::PauliStringTS) = UnorderedDictionary{typeof(pauli),ComplexF64}()
+emptydict(pauli::PauliStringTS) = UnorderedDictionary{typeof(pauli), ComplexF64}()
 
-function binary_kernel(op, A::PauliStringTS, B::PauliStringTS; maxlength=1000, epsilon=1e-16)
+function binary_kernel(op, A::PauliStringTS, B::PauliStringTS; maxlength = 1000, epsilon = 1.0e-16)
     # checklength(A, B)
     Ls = qubitsize(A)
     Ps = periodicflags(A)
@@ -188,10 +185,10 @@ function binary_kernel(op, A::PauliStringTS, B::PauliStringTS; maxlength=1000, e
         p, k = op(rep1, shift(rep2, Ls, Ps, s))
         c = c1 * c2 * k
         if (k != 0) && (abs(c) > epsilon) && pauli_weight(p) < maxlength
-            setwith!(+, d, PauliStringTS{Ls,Ps}(p), c)
+            setwith!(+, d, PauliStringTS{Ls, Ps}(p), c)
         end
     end
-    o = Operator{typeof(A),ComplexF64}(collect(keys(d)), collect(values(d)))
+    o = Operator{typeof(A), ComplexF64}(collect(keys(d)), collect(values(d)))
     return (eltype(o.coeffs) == ComplexF64) ? cutoff(o, epsilon) : o
 end
 

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -28,7 +28,7 @@ Returns the type of the coefficients used in the operator.
 scalartype
 scalartype(o::AbstractOperator) = scalartype(typeof(o))
 # avoid infinite recursion:
-scalartype(::Type{<:AbstractOperator}) = throw(MethodError(scalartype, T))
+scalartype(T::Type{<:AbstractOperator}) = throw(MethodError(scalartype, T))
 
 Base.one(x::AbstractOperator) = one(typeof(x))
 Base.zero(x::AbstractOperator) = zero(typeof(x))

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -1,3 +1,4 @@
+
 @doc """
     paulistringtype(x::AbstractOperator)
     paulistringtype(::Type{<:AbstractOperator})
@@ -41,7 +42,7 @@ A concrete type representing an operator as a sum of Pauli strings.
 The operator is represented as a vector of Pauli strings and their corresponding coefficients.
 The type parameters `P` and `T` specify the type of the Pauli strings and the type of the coefficients, respectively.
 """
-struct Operator{P <: AbstractPauliString, T <: Number} <: AbstractOperator
+struct Operator{P<:AbstractPauliString,T<:Number} <: AbstractOperator
     strings::Vector{P}
     coeffs::Vector{T}
 end
@@ -51,39 +52,40 @@ end
 
 Initialize a zero operator on `N` qubits.
 """
-Operator(N::Integer) = Operator{paulistringtype(N), ComplexF64}()
-Operator{P, T}() where {P, T} = Operator{P, T}(P[], T[])
+Operator(N::Integer) = Operator{paulistringtype(N),ComplexF64}()
+Operator{P,T}() where {P,T} = Operator{P,T}(P[], T[])
 # Operator(strings::Vector{<:AbstractPauliString}, coeffs::Vector{<:Number}) = Operator{eltype(strings),eltype(coeffs)}(strings, coeffs)
 
-function Operator(N::Int, v::Vector{T}, w::Vector{T}, coef::Vector{Complex{Float64}}) where {T <: Unsigned}
+function Operator(N::Int, v::Vector{T}, w::Vector{T}, coef::Vector{Complex{Float64}}) where {T<:Unsigned}
     length(v) == length(w) == length(coef) || error("v, w, and coef must have the same length")
     P = paulistringtype(N)
     strings = P.(v, w)
-    return Operator{P, ComplexF64}(strings, coef)
+    return Operator{P,ComplexF64}(strings, coef)
 end
 
 Operator(pauli::AbstractString) = Operator{paulistringtype(length(pauli))}(pauli)
-Operator{P}(pauli::AbstractString) where {P} = Operator{P, ComplexF64}(pauli)
-function Operator{P, T}(pauli::AbstractString) where {P, T}
+Operator{P}(pauli::AbstractString) where {P} = Operator{P,ComplexF64}(pauli)
+function Operator{P,T}(pauli::AbstractString) where {P,T}
     s = P(pauli)
     c = T((1.0im)^ycount(s))
-    return Operator{P, T}([s], [c])
+    return Operator{P,T}([s], [c])
 end
 
 Operator(o::Operator) = copy(o)
 Base.copy(o::Operator) = typeof(o)(copy(o.strings), copy(o.coeffs))
 
-Operator(pauli::PauliString) = Operator{typeof(pauli), ComplexF64}([pauli], [(1.0im)^ycount(pauli)])
+
+Operator(pauli::PauliString) = Operator{typeof(pauli),ComplexF64}([pauli], [(1.0im)^ycount(pauli)])
 
 paulistringtype(::Type{<:Operator{P}}) where {P} = P
-scalartype(::Type{Operator{P, T}}) where {P, T} = T
+scalartype(::Type{Operator{P,T}}) where {P,T} = T
 
 Base.keys(o::Operator) = o.strings
 Base.values(o::Operator) = o.coeffs
 Base.pairs(o::Operator) = (p => c for (p, c) in zip(keys(o), values(o)))
 
-Base.one(::Type{O}) where {O <: Operator} = O([one(paulistringtype(O))], [one(scalartype(O))])
-Base.zero(::Type{O}) where {O <: Operator} = O()
+Base.one(::Type{O}) where {O<:Operator} = O([one(paulistringtype(O))], [one(scalartype(O))])
+Base.zero(::Type{O}) where {O<:Operator} = O()
 
 """
     Base.length(o::Operator)
@@ -102,6 +104,7 @@ julia> length(A)
 """
 Base.length(o::Union{Operator}) = length(keys(o))
 
+
 """
     eye(N::Int)
 
@@ -109,7 +112,11 @@ Identity operator on N qubits
 """
 eye(N::Int) = Operator(N) + 1
 
-Base.getindex(o::AbstractOperator, i::Int) = (values(o)[i] / (1im)^ycount(keys(o)[i]), keys(o)[i])
+
+
+Base.getindex(o::AbstractOperator, i::Int) = (values(o)[i]/(1im)^ycount(keys(o)[i]), keys(o)[i])
+
+
 
 # Utility functions
 # -----------------

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -1,4 +1,3 @@
-
 @doc """
     paulistringtype(x::AbstractOperator)
     paulistringtype(::Type{<:AbstractOperator})
@@ -42,7 +41,7 @@ A concrete type representing an operator as a sum of Pauli strings.
 The operator is represented as a vector of Pauli strings and their corresponding coefficients.
 The type parameters `P` and `T` specify the type of the Pauli strings and the type of the coefficients, respectively.
 """
-struct Operator{P<:AbstractPauliString,T<:Number} <: AbstractOperator
+struct Operator{P <: AbstractPauliString, T <: Number} <: AbstractOperator
     strings::Vector{P}
     coeffs::Vector{T}
 end
@@ -52,36 +51,39 @@ end
 
 Initialize a zero operator on `N` qubits.
 """
-Operator(N::Integer) = Operator{paulistringtype(N),ComplexF64}()
-Operator{P,T}() where {P,T} = Operator{P,T}(P[], T[])
+Operator(N::Integer) = Operator{paulistringtype(N), ComplexF64}()
+Operator{P, T}() where {P, T} = Operator{P, T}(P[], T[])
 # Operator(strings::Vector{<:AbstractPauliString}, coeffs::Vector{<:Number}) = Operator{eltype(strings),eltype(coeffs)}(strings, coeffs)
 
-function Operator(N::Int, v::Vector{T}, w::Vector{T}, coef::Vector{Complex{Float64}}) where {T<:Unsigned}
+function Operator(N::Int, v::Vector{T}, w::Vector{T}, coef::Vector{Complex{Float64}}) where {T <: Unsigned}
     length(v) == length(w) == length(coef) || error("v, w, and coef must have the same length")
     P = paulistringtype(N)
     strings = P.(v, w)
-    return Operator{P,ComplexF64}(strings, coef)
+    return Operator{P, ComplexF64}(strings, coef)
 end
 
 Operator(pauli::AbstractString) = Operator{paulistringtype(length(pauli))}(pauli)
-Operator{P}(pauli::AbstractString) where {P} = Operator{P,ComplexF64}(pauli)
-function Operator{P,T}(pauli::AbstractString) where {P,T}
+Operator{P}(pauli::AbstractString) where {P} = Operator{P, ComplexF64}(pauli)
+function Operator{P, T}(pauli::AbstractString) where {P, T}
     s = P(pauli)
     c = T((1.0im)^ycount(s))
-    return Operator{P,T}([s], [c])
+    return Operator{P, T}([s], [c])
 end
 
-Operator(o::Operator) = Operator(copy(o.strings), copy(o.coeffs))
+Operator(o::Operator) = copy(o)
+Base.copy(o::Operator) = typeof(o)(copy(o.strings), copy(o.coeffs))
 
-
-Operator(pauli::PauliString) = Operator{typeof(pauli),ComplexF64}([pauli], [(1.0im)^ycount(pauli)])
+Operator(pauli::PauliString) = Operator{typeof(pauli), ComplexF64}([pauli], [(1.0im)^ycount(pauli)])
 
 paulistringtype(::Type{<:Operator{P}}) where {P} = P
-scalartype(::Type{Operator{P,T}}) where {P,T} = T
+scalartype(::Type{Operator{P, T}}) where {P, T} = T
 
-Base.one(::Type{O}) where {O<:Operator} = O([one(paulistringtype(O))], [one(scalartype(O))])
-Base.zero(::Type{O}) where {O<:Operator} = O()
-Base.copy(o::Operator) = typeof(o)(copy(o.strings), copy(o.coeffs))
+Base.keys(o::Operator) = o.strings
+Base.values(o::Operator) = o.coeffs
+Base.pairs(o::Operator) = (p => c for (p, c) in zip(keys(o), values(o)))
+
+Base.one(::Type{O}) where {O <: Operator} = O([one(paulistringtype(O))], [one(scalartype(O))])
+Base.zero(::Type{O}) where {O <: Operator} = O()
 
 """
     Base.length(o::Operator)
@@ -98,8 +100,7 @@ julia> length(A)
 3
 ```
 """
-Base.length(o::Union{Operator}) = length(o.strings)
-
+Base.length(o::Union{Operator}) = length(keys(o))
 
 """
     eye(N::Int)
@@ -108,11 +109,7 @@ Identity operator on N qubits
 """
 eye(N::Int) = Operator(N) + 1
 
-
-
-Base.getindex(o::AbstractOperator, i::Int) = (o.coeffs[i]/(1im)^ycount(o.strings[i]), o.strings[i])
-
-
+Base.getindex(o::AbstractOperator, i::Int) = (values(o)[i] / (1im)^ycount(keys(o)[i]), keys(o)[i])
 
 # Utility functions
 # -----------------

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -121,5 +121,3 @@ checklength(::Type{Bool}, o1::AbstractOperator, o2::AbstractOperator) = qubitlen
 checklength(::Type{Bool}, o1::AbstractOperator, o2::AbstractOperator...) = checklength(Bool, o1, first(o2)) & checklength(Bool, o1, tail(o2)...)
 
 checklength(o1::AbstractOperator, o2::AbstractOperator...) = checklength(Bool, o1, o2...) || throw(DimensionMismatch("Operators must have the same number of qubits"))
-checklength(::Type{Bool}, o1::AbstractOperator, o2::PauliString) = qubitlength(o1) == qubitlength(o2)
-checklength(::Type{Bool}, o1::PauliString, o2::AbstractOperator) = qubitlength(o1) == qubitlength(o2)

--- a/src/paulistring.jl
+++ b/src/paulistring.jl
@@ -5,7 +5,7 @@ Abstract supertype for operators that can be represented in terms of Pauli strin
 """
 abstract type AbstractOperator end
 
-Base.pairs(o::AbstractOperator) = (p => c for (p, c) in zip(keys(o), values(o)))
+Base.pairs(o::AbstractOperator) = zip(keys(o), values(o))
 
 """
     AbstractPauliString

--- a/src/paulistring.jl
+++ b/src/paulistring.jl
@@ -1,4 +1,3 @@
-
 """
     AbstractOperator
 
@@ -6,6 +5,7 @@ Abstract supertype for operators that can be represented in terms of Pauli strin
 """
 abstract type AbstractOperator end
 
+Base.pairs(o::AbstractOperator) = (p => c for (p, c) in zip(keys(o), values(o)))
 
 """
     AbstractPauliString
@@ -14,9 +14,10 @@ Abstract supertype for Pauli strings, ie strings of Pauli operators (I, X, Y, Z)
 """
 abstract type AbstractPauliString <: AbstractOperator end
 
+Base.keys(p::AbstractPauliString) = (p,)
+Base.values(p::AbstractPauliString) = ((1.0im)^ycount(p),)
 
-
-paulistringtype(::Type{P}) where {P<:AbstractPauliString} = P
+paulistringtype(::Type{P}) where {P <: AbstractPauliString} = P
 
 """
     PauliString{N,T<:Unsigned} <: AbstractPauliString
@@ -24,17 +25,17 @@ paulistringtype(::Type{P}) where {P<:AbstractPauliString} = P
 A concrete type representing a Pauli string on `N` qubits as a pair of unsigned integers, as
 described in https://journals.aps.org/pra/abstract/10.1103/PhysRevA.68.042318.
 """
-struct PauliString{N,T<:Unsigned} <: AbstractPauliString
+struct PauliString{N, T <: Unsigned} <: AbstractPauliString
     v::T
     w::T
 end
 
 qubitlength(::Type{<:PauliString{N}}) where {N} = N
-PauliString{N}(v::Integer, w::Integer) where {N} = PauliString{N,uinttype(N)}(v, w)
+PauliString{N}(v::Integer, w::Integer) where {N} = PauliString{N, uinttype(N)}(v, w)
 
 
 function define_bitintegers(bits::Integer)
-    @eval BitIntegers begin
+    return @eval BitIntegers begin
         BitIntegers.@define_integers $bits $(Symbol("Int$(bits)")) $(Symbol("UInt$(bits)"))
     end
 end
@@ -48,12 +49,12 @@ function uinttype(N::Integer)
     return getfield(BitIntegers, Symbol("UInt$(bits)"))
 end
 
-paulistringtype(N::Integer) = PauliString{N,uinttype(N)}
+paulistringtype(N::Integer) = PauliString{N, uinttype(N)}
 
 PauliString(pauli::AbstractString) = PauliString{length(pauli)}(pauli)
-PauliString{N}(pauli::AbstractString) where {N} = PauliString{N,uinttype(N)}(pauli)
+PauliString{N}(pauli::AbstractString) where {N} = PauliString{N, uinttype(N)}(pauli)
 
-function PauliString{N,T}(pauli::AbstractString) where {N,T}
+function PauliString{N, T}(pauli::AbstractString) where {N, T}
     length(pauli) == N || throw(ArgumentError("pauli string length must be $N"))
     v = zero(T)
     w = zero(T)
@@ -73,11 +74,11 @@ function PauliString{N,T}(pauli::AbstractString) where {N,T}
         end
     end
 
-    return PauliString{N,T}(v, w)
+    return PauliString{N, T}(v, w)
 end
 
-Base.one(::Type{PauliString{N,T}}) where {N,T} = PauliString{N,T}(zero(T), zero(T))
-Base.copy(p::PauliString{N,T}) where {N,T} = PauliString{N,T}(copy(p.v), copy(p.w))
+Base.one(::Type{PauliString{N, T}}) where {N, T} = PauliString{N, T}(zero(T), zero(T))
+Base.copy(p::PauliString{N, T}) where {N, T} = PauliString{N, T}(copy(p.v), copy(p.w))
 
 # TODO: should we use `Char` instead of `Symbol`?
 # TODO: should we use `:I` or `Symbol(1)` for identity?
@@ -120,11 +121,11 @@ end
 
 Convert a PauliString to its string representation.
 """
-Base.string(x::PauliString) = join([x[i] for i = 1:qubitlength(x)])
+Base.string(x::PauliString) = join([x[i] for i in 1:qubitlength(x)])
 
-Base.unsigned(p::PauliString{N,T}) where {N,T} = (widen(p.v) << N + p.w)
+Base.unsigned(p::PauliString{N, T}) where {N, T} = (widen(p.v) << N + p.w)
 
-function LinearAlgebra.norm(p::PauliString; normalize=false)
+function LinearAlgebra.norm(p::PauliString; normalize = false)
     normalize && return 1.0
     return sqrt(2.0^qubitlength(p))
 end
@@ -141,7 +142,7 @@ julia> PauliString{4}(I)
 1111
 ```
 """
-PauliString{N}(::LinearAlgebra.UniformScaling) where {N} = PauliString{N,uinttype(N)}(zero(uinttype(N)), zero(uinttype(N)))
+PauliString{N}(::LinearAlgebra.UniformScaling) where {N} = PauliString{N, uinttype(N)}(zero(uinttype(N)), zero(uinttype(N)))
 
 
 """

--- a/src/paulistring.jl
+++ b/src/paulistring.jl
@@ -16,8 +16,10 @@ abstract type AbstractPauliString <: AbstractOperator end
 
 Base.keys(p::AbstractPauliString) = (p,)
 Base.values(p::AbstractPauliString) = ((1.0im)^ycount(p),)
+Base.length(p::AbstractPauliString) = 1
 
 paulistringtype(::Type{P}) where {P <: AbstractPauliString} = P
+scalartype(::Type{P}) where {P <: AbstractPauliString} = Float64 # default
 
 """
     PauliString{N,T<:Unsigned} <: AbstractPauliString

--- a/src/paulistring.jl
+++ b/src/paulistring.jl
@@ -1,3 +1,4 @@
+
 """
     AbstractOperator
 
@@ -18,8 +19,8 @@ Base.keys(p::AbstractPauliString) = (p,)
 Base.values(p::AbstractPauliString) = ((1.0im)^ycount(p),)
 Base.length(p::AbstractPauliString) = 1
 
-paulistringtype(::Type{P}) where {P <: AbstractPauliString} = P
-scalartype(::Type{P}) where {P <: AbstractPauliString} = Float64 # default
+paulistringtype(::Type{P}) where {P<:AbstractPauliString} = P
+scalartype(::Type{P}) where {P<:AbstractPauliString} = Float64 # default
 
 """
     PauliString{N,T<:Unsigned} <: AbstractPauliString
@@ -27,17 +28,17 @@ scalartype(::Type{P}) where {P <: AbstractPauliString} = Float64 # default
 A concrete type representing a Pauli string on `N` qubits as a pair of unsigned integers, as
 described in https://journals.aps.org/pra/abstract/10.1103/PhysRevA.68.042318.
 """
-struct PauliString{N, T <: Unsigned} <: AbstractPauliString
+struct PauliString{N,T<:Unsigned} <: AbstractPauliString
     v::T
     w::T
 end
 
 qubitlength(::Type{<:PauliString{N}}) where {N} = N
-PauliString{N}(v::Integer, w::Integer) where {N} = PauliString{N, uinttype(N)}(v, w)
+PauliString{N}(v::Integer, w::Integer) where {N} = PauliString{N,uinttype(N)}(v, w)
 
 
 function define_bitintegers(bits::Integer)
-    return @eval BitIntegers begin
+    @eval BitIntegers begin
         BitIntegers.@define_integers $bits $(Symbol("Int$(bits)")) $(Symbol("UInt$(bits)"))
     end
 end
@@ -51,12 +52,12 @@ function uinttype(N::Integer)
     return getfield(BitIntegers, Symbol("UInt$(bits)"))
 end
 
-paulistringtype(N::Integer) = PauliString{N, uinttype(N)}
+paulistringtype(N::Integer) = PauliString{N,uinttype(N)}
 
 PauliString(pauli::AbstractString) = PauliString{length(pauli)}(pauli)
-PauliString{N}(pauli::AbstractString) where {N} = PauliString{N, uinttype(N)}(pauli)
+PauliString{N}(pauli::AbstractString) where {N} = PauliString{N,uinttype(N)}(pauli)
 
-function PauliString{N, T}(pauli::AbstractString) where {N, T}
+function PauliString{N,T}(pauli::AbstractString) where {N,T}
     length(pauli) == N || throw(ArgumentError("pauli string length must be $N"))
     v = zero(T)
     w = zero(T)
@@ -76,11 +77,11 @@ function PauliString{N, T}(pauli::AbstractString) where {N, T}
         end
     end
 
-    return PauliString{N, T}(v, w)
+    return PauliString{N,T}(v, w)
 end
 
-Base.one(::Type{PauliString{N, T}}) where {N, T} = PauliString{N, T}(zero(T), zero(T))
-Base.copy(p::PauliString{N, T}) where {N, T} = PauliString{N, T}(copy(p.v), copy(p.w))
+Base.one(::Type{PauliString{N,T}}) where {N,T} = PauliString{N,T}(zero(T), zero(T))
+Base.copy(p::PauliString{N,T}) where {N,T} = PauliString{N,T}(copy(p.v), copy(p.w))
 
 # TODO: should we use `Char` instead of `Symbol`?
 # TODO: should we use `:I` or `Symbol(1)` for identity?
@@ -123,11 +124,11 @@ end
 
 Convert a PauliString to its string representation.
 """
-Base.string(x::PauliString) = join([x[i] for i in 1:qubitlength(x)])
+Base.string(x::PauliString) = join([x[i] for i = 1:qubitlength(x)])
 
-Base.unsigned(p::PauliString{N, T}) where {N, T} = (widen(p.v) << N + p.w)
+Base.unsigned(p::PauliString{N,T}) where {N,T} = (widen(p.v) << N + p.w)
 
-function LinearAlgebra.norm(p::PauliString; normalize = false)
+function LinearAlgebra.norm(p::PauliString; normalize=false)
     normalize && return 1.0
     return sqrt(2.0^qubitlength(p))
 end
@@ -144,7 +145,7 @@ julia> PauliString{4}(I)
 1111
 ```
 """
-PauliString{N}(::LinearAlgebra.UniformScaling) where {N} = PauliString{N, uinttype(N)}(zero(uinttype(N)), zero(uinttype(N)))
+PauliString{N}(::LinearAlgebra.UniformScaling) where {N} = PauliString{N,uinttype(N)}(zero(uinttype(N)), zero(uinttype(N)))
 
 
 """

--- a/src/states.jl
+++ b/src/states.jl
@@ -10,19 +10,14 @@ Computes `<0|o|0>`.
 """
 function trace_zpart(o::Operator)
     s = zero(scalartype(o))
-    N = qubitlength(o)
 
-    # ensure `@inbounds` is safe
-    length(o.strings) == length(o.coeffs) || throw(DimensionMismatch("strings and coefficients must have the same length"))
-
-    @inbounds for i in 1:length(o)
-        p, c = o.strings[i], o.coeffs[i]
+    for (p, c) in pairs(o)
         if (xcount(p) == 0) & (ycount(p) == 0)
             s += c
         end
     end
 
-    return s * 2.0^N
+    return s * 2.0^qubitlength(o)
 end
 
 
@@ -33,7 +28,7 @@ function get_ox(state)
     for i in 1:N
         if state[i] == '1'
             x = XGate(N, i)
-            ox = ox*x
+            ox = ox * x
         end
     end
     return compress(ox)
@@ -61,11 +56,9 @@ function expect(o::Operator, in_state::String, out_state::String)
     N == length(in_state) == length(out_state) || throw(DimensionMismatch("State length does not match operator size"))
     ox_in = get_ox(in_state)
     ox_out = get_ox(out_state)
-    o2 = ox_out*o*ox_in
+    o2 = ox_out * o * ox_in
     return trace_zpart(o2) / 2.0^N
 end
-
-
 
 
 """
@@ -80,7 +73,7 @@ function expect_product(o1::Operator, o2::Operator, state::String)
     N = qubitlength(o1)
     @assert length(state) == N "State length does not match operator size"
     ox = get_ox(state)
-    return trace_product_z(ox * o1, o2 * ox; scale=0) / 2.0^N
+    return trace_product_z(ox * o1, o2 * ox; scale = 0) / 2.0^N
 end
 
 
@@ -92,7 +85,7 @@ State is a single binary string that represents a pure state in the computationa
 """
 function expect(c::Circuit, state::String)
     @assert Set(state) ⊆ Set("01") "State must be a string of 0s and 1s"
-    in_state = "0" ^ c.N
+    in_state = "0"^c.N
     return expect(c, in_state, state)
 end
 

--- a/src/states.jl
+++ b/src/states.jl
@@ -28,7 +28,7 @@ function get_ox(state)
     for i in 1:N
         if state[i] == '1'
             x = XGate(N, i)
-            ox = ox * x
+            ox = ox*x
         end
     end
     return compress(ox)
@@ -56,9 +56,11 @@ function expect(o::Operator, in_state::String, out_state::String)
     N == length(in_state) == length(out_state) || throw(DimensionMismatch("State length does not match operator size"))
     ox_in = get_ox(in_state)
     ox_out = get_ox(out_state)
-    o2 = ox_out * o * ox_in
+    o2 = ox_out*o*ox_in
     return trace_zpart(o2) / 2.0^N
 end
+
+
 
 
 """
@@ -73,7 +75,7 @@ function expect_product(o1::Operator, o2::Operator, state::String)
     N = qubitlength(o1)
     @assert length(state) == N "State length does not match operator size"
     ox = get_ox(state)
-    return trace_product_z(ox * o1, o2 * ox; scale = 0) / 2.0^N
+    return trace_product_z(ox * o1, o2 * ox; scale=0) / 2.0^N
 end
 
 
@@ -85,7 +87,7 @@ State is a single binary string that represents a pure state in the computationa
 """
 function expect(c::Circuit, state::String)
     @assert Set(state) ⊆ Set("01") "State must be a string of 0s and 1s"
-    in_state = "0"^c.N
+    in_state = "0" ^ c.N
     return expect(c, in_state, state)
 end
 

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -4,13 +4,13 @@
 Type representing a translation symmetric sum of a Pauli string. The tuple `Ls` specifies the period in each dimension.
 The tuple `Ps` specifies which dimensions are periodic (true) or open (false). By default all dimensions are periodic.
 """
-struct PauliStringTS{Ls, Ps, T <: Unsigned} <: AbstractPauliString
+struct PauliStringTS{Ls,Ps,T<:Unsigned} <: AbstractPauliString
     v::T
     w::T
 end
 
-periodicpaulistringtype(Ls::NTuple{<:Any, Integer}) = PauliStringTS{Ls, ntuple(i -> true, length(Ls)), uinttype(Base.prod(Ls))}
-periodicpaulistringtype(Ls::NTuple{<:Any, Integer}, Ps::NTuple{<:Any, Bool}) = PauliStringTS{Ls, Ps, uinttype(Base.prod(Ls))}
+periodicpaulistringtype(Ls::NTuple{<:Any,Integer}) = PauliStringTS{Ls,ntuple(i -> true, length(Ls)),uinttype(Base.prod(Ls))}
+periodicpaulistringtype(Ls::NTuple{<:Any,Integer}, Ps::NTuple{<:Any,Bool}) = PauliStringTS{Ls,Ps,uinttype(Base.prod(Ls))}
 qubitlength(::Type{<:PauliStringTS{Ls}}) where {Ls} = Base.prod(Ls)
 
 """
@@ -28,7 +28,7 @@ qubitsize(p::PauliStringTS) = qubitsize(typeof(p))
 
 Get the tuple of periodic flags of a given `PauliStringTS`.
 """
-periodicflags(::Type{<:PauliStringTS{Ls, Ps}}) where {Ls, Ps} = Ps
+periodicflags(::Type{<:PauliStringTS{Ls,Ps}}) where {Ls,Ps} = Ps
 periodicflags(p::PauliStringTS) = periodicflags(typeof(p))
 
 for count in [:xcount, :ycount, :zcount, :pauli_weight]
@@ -45,7 +45,7 @@ function Base.string(p::PauliStringTS)
             return join(join.(eachcol(slice)), "\n")
         end
 
-        segments = str.(eachslice(slice, dims = ((3:ndims(slice))...,)))
+        segments = str.(eachslice(slice, dims=((3:ndims(slice))...,)))
 
         return join(["[:, :, $(join(Tuple(I), ", "))] =\n" * segments[I] for I in CartesianIndices(segments)], "\n\n")
     end
@@ -53,7 +53,7 @@ function Base.string(p::PauliStringTS)
     return str(σij)
 end
 
-Base.one(::Type{<:PauliStringTS{Ls, Ps, T}}) where {Ls, Ps, T} = PauliStringTS{Ls, Ps}(one(PauliString{Base.prod(Ls), T}))
+Base.one(::Type{<:PauliStringTS{Ls,Ps,T}}) where {Ls,Ps,T} = PauliStringTS{Ls,Ps}(one(PauliString{Base.prod(Ls),T}))
 Base.isless(a::PauliStringTS, b::PauliStringTS) = isless(representative(a), representative(b))
 
 """
@@ -64,10 +64,10 @@ Construct a translation symmetric sum of a Pauli string `p`. `Ls` is a tuple tha
 `Ps` is an optional tuple of Bool values indicating which dimensions are periodic (default: all true).
 """
 function PauliStringTS{Ls}(p::PauliString) where {Ls}
-    return PauliStringTS{Ls, ntuple(i -> true, length(Ls))}(p)
+    return PauliStringTS{Ls,ntuple(i -> true, length(Ls))}(p)
 end
 
-function PauliStringTS{Ls, Ps}(p::PauliString) where {Ls, Ps}
+function PauliStringTS{Ls,Ps}(p::PauliString) where {Ls,Ps}
     if !(Ls isa Tuple)
         error("Cannot construct PauliStringTS{$Ls}: $Ls is not a Tuple")
     end
@@ -84,7 +84,7 @@ function PauliStringTS{Ls, Ps}(p::PauliString) where {Ls, Ps}
     end
 
     rep = find_representative(p, Ls, Ps)
-    return PauliStringTS{Ls, Ps, typeof(rep.v)}(rep.v, rep.w)
+    return PauliStringTS{Ls,Ps,typeof(rep.v)}(rep.v, rep.w)
 end
 
 PauliStringTS{Ls}(pauli::AbstractString) where {Ls} = PauliStringTS{Ls}(PauliString(pauli))
@@ -95,7 +95,7 @@ PauliStringTS{Ls}(pauli::AbstractString) where {Ls} = PauliStringTS{Ls}(PauliStr
 
 Returns a unique representative string of the translation symmetric sum of the Pauli string `p`.
 """
-representative(p::PauliStringTS{Ls, Ps, T}) where {Ls, Ps, T} = PauliString{Base.prod(Ls), T}(p.v, p.w)
+representative(p::PauliStringTS{Ls,Ps,T}) where {Ls,Ps,T} = PauliString{Base.prod(Ls),T}(p.v, p.w)
 
 @inline function find_representative(p::PauliString, Ls)
     return find_representative(p, Ls, ntuple(i -> true, length(Ls)))
@@ -121,7 +121,7 @@ end
     # For each dimension, if periodic, generate all shifts 1:L, otherwise just 1 (identity)
     return Iterators.product(map((L, p) -> p ? (1:L) : (1:1), Ls, Ps)...)
 end
-@inline all_shifts(::Type{<:PauliStringTS{Ls, Ps}}) where {Ls, Ps} = all_shifts(Ls, Ps)
+@inline all_shifts(::Type{<:PauliStringTS{Ls,Ps}}) where {Ls,Ps} = all_shifts(Ls, Ps)
 
 """
     shift(p::PauliString, Ls::Tuple, shifts::Tuple)
@@ -132,11 +132,11 @@ end
 Interpret a PauliString as a multidimensional array whose size is given by the tuple `Ls` and apply a tuple of periodic `shifts` in the different dimensions to it.
 `Ps` is an optional tuple of Bool values indicating which dimensions are periodic (default: all true).
 """
-@inline shift(p::PauliString{N, T}, Ls::Tuple, shifts::Tuple) where {N, T} =
+@inline shift(p::PauliString{N,T}, Ls::Tuple, shifts::Tuple) where {N,T} =
     shift(p, Ls, ntuple(i -> true, length(Ls)), shifts)
 
-@inline shift(p::PauliString{N, T}, Ls::Tuple, Ps::Tuple, shifts::Tuple) where {N, T} =
-    PauliString{N, T}(_shift(p.v, Ls, Ps, shifts), _shift(p.w, Ls, Ps, shifts))
+@inline shift(p::PauliString{N,T}, Ls::Tuple, Ps::Tuple, shifts::Tuple) where {N,T} =
+    PauliString{N,T}(_shift(p.v, Ls, Ps, shifts), _shift(p.w, Ls, Ps, shifts))
 
 shift(p::Operator, Ls::Tuple, shifts::Tuple) = shift(p, Ls, ntuple(i -> true, length(Ls)), shifts)
 shift(p::Operator, Ls::Tuple, Ps::Tuple, shifts::Tuple) = Operator(shift.(p.strings, Ref(Ls), Ref(Ps), Ref(shifts)), copy(p.coeffs))
@@ -147,7 +147,7 @@ shift(p::Operator, Ls::Tuple, Ps::Tuple, shifts::Tuple) = Operator(shift.(p.stri
 
 Shift `p` by `r` bits, assuming it lives in 1D.
 """
-shift(p::Union{PauliString, Operator}, r::Integer) = shift(p, (qubitlength(p),), (r,))
+shift(p::Union{PauliString,Operator}, r::Integer) = shift(p, (qubitlength(p),), (r,))
 
 """
     _shift(x::Unsigned, Ls::Tuple, shifts::Tuple)
@@ -189,7 +189,7 @@ Periodically shift `x` by `s` bits within periodic windows of length `stride`.
     return (x << s) & (~(magicmask >> rshift)) | ((x & magicmask) >> rshift)
 end
 
-const OperatorTS{Ls, Ps, U, T} = Operator{PauliStringTS{Ls, Ps, U}, T}
+const OperatorTS{Ls,Ps,U,T} = Operator{PauliStringTS{Ls,Ps,U},T}
 
 @doc raw"""
     OperatorTS{Ls}(o::Operator)
@@ -207,13 +207,13 @@ where ``T`` are all translations on the `L1`×`L2`×… hypercube. So if you fee
 To get a dense operator from this lazy sum representation, see [`resum`](@ref). To get a single term, see [`representative`](@ref).
 """
 function OperatorTS{Ls}(o::Operator) where {Ls}
-    return OperatorTS{Ls, ntuple(i -> true, length(Ls))}(o)
+    return OperatorTS{Ls,ntuple(i -> true, length(Ls))}(o)
 end
 
-function OperatorTS{Ls, Ps}(o::Operator) where {Ls, Ps}
-    periodic_strings = PauliStringTS{Ls, Ps}.(o.strings)
+function OperatorTS{Ls,Ps}(o::Operator) where {Ls,Ps}
+    periodic_strings = PauliStringTS{Ls,Ps}.(o.strings)
     coeffs = copy(o.coeffs)
-    return compress(Operator{eltype(periodic_strings), eltype(coeffs)}(periodic_strings, coeffs))
+    return compress(Operator{eltype(periodic_strings),eltype(coeffs)}(periodic_strings, coeffs))
 end
 
 
@@ -221,7 +221,7 @@ OperatorTS{Ls}(pauli::PauliString) where {Ls} = OperatorTS{Ls}(Operator(pauli))
 function OperatorTS(pauli::PauliStringTS)
     periodic_strings = [pauli]
     coeffs = [1.0im^ycount(pauli)]
-    return compress(Operator{eltype(periodic_strings), eltype(coeffs)}(periodic_strings, coeffs))
+    return compress(Operator{eltype(periodic_strings),eltype(coeffs)}(periodic_strings, coeffs))
 end
 OperatorTS{Ls}(pauli::AbstractString) where {Ls} = OperatorTS{Ls}(PauliString(pauli))
 
@@ -229,7 +229,7 @@ OperatorTS{Ls}(pauli::AbstractString) where {Ls} = OperatorTS{Ls}(PauliString(pa
 qubitsize(::Type{<:OperatorTS{Ls}}) where {Ls} = Ls
 qubitsize(op::Operator{<:PauliStringTS}) = qubitsize(typeof(op))
 
-periodicflags(::Type{<:OperatorTS{Ls, Ps}}) where {Ls, Ps} = Ps
+periodicflags(::Type{<:OperatorTS{Ls,Ps}}) where {Ls,Ps} = Ps
 periodicflags(op::Operator{<:PauliStringTS}) = periodicflags(typeof(op))
 
 """
@@ -274,7 +274,7 @@ end
 
 Base.@deprecate opnorm(o::Operator{<:PauliStringTS}) LinearAlgebra.norm(o::Operator{<:PauliStringTS})
 
-function LinearAlgebra.norm(o::Operator{<:PauliStringTS}; normalize = false)
+function LinearAlgebra.norm(o::Operator{<:PauliStringTS}; normalize=false)
     n = sqrt(real(trace_product(o', o)))
     if normalize
         return n / (2.0^(qubitlength(o) / 2))
@@ -283,7 +283,7 @@ function LinearAlgebra.norm(o::Operator{<:PauliStringTS}; normalize = false)
     end
 end
 
-function LinearAlgebra.norm(p::PauliStringTS; normalize = false)
+function LinearAlgebra.norm(p::PauliStringTS; normalize=false)
     normalize && return sqrt(qubitlength(p))
     return sqrt(2.0^qubitlength(p) * qubitlength(p))
 end
@@ -320,7 +320,7 @@ return true if `o` is translation symmetric on a rectangle with sidelengths `L1`
 `Ps` is an optional tuple of Bool values indicating which dimensions are periodic (default: both true).
 """
 is_ts2d(o, L1) = is_ts(o, (L1, qubitlength(o) ÷ L1), (true, true))
-is_ts2d(o, L1, Ps::NTuple{2, Bool}) = is_ts(o, (L1, qubitlength(o) ÷ L1), Ps)
+is_ts2d(o, L1, Ps::NTuple{2,Bool}) = is_ts(o, (L1, qubitlength(o) ÷ L1), Ps)
 
 
 Base.:+(a::Number, o::Operator{<:PauliStringTS}) = begin
@@ -328,7 +328,7 @@ Base.:+(a::Number, o::Operator{<:PauliStringTS}) = begin
     Ls = qubitsize(o)
     Ps = periodicflags(o)
     num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
-    OperatorTS{qubitsize(o), periodicflags(o)}(representative(o) + a / num_translations)
+    OperatorTS{qubitsize(o),periodicflags(o)}(representative(o) + a / num_translations)
 end
 Base.:+(o::Operator{<:PauliStringTS}, a::Number) = a + o
 
@@ -339,17 +339,17 @@ Base.:+(o::Operator{<:PauliStringTS}, a::Number) = a + o
 
 Initialize a zero 2D translation-invariant operator on `N` qubits, with extent of `L1` in the ``a_1`` direction.
 """
-OperatorTS2D(N::Integer, L1::Integer) = (N % L1 == 0) ? Operator{periodicpaulistringtype((L1, N ÷ L1)), ComplexF64}() : error("N must be divisible by L1")
+OperatorTS2D(N::Integer, L1::Integer) = (N % L1 == 0) ? Operator{periodicpaulistringtype((L1, N ÷ L1)),ComplexF64}() : error("N must be divisible by L1")
 
-function OperatorTS2D(N::Int, L1::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T <: Unsigned}
+function OperatorTS2D(N::Int, L1::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T<:Unsigned}
     length(v) == length(w) == length(coef) || error("v, w, and coef must have the same length")
     P = periodicpaulistringtype((L1, N ÷ L1))
     strings = P.(v, w)
     return Operator(strings, coef)
 end
 
-OperatorTS2D(pauli::AbstractString, L1::Integer) = Operator{periodicpaulistringtype((L1, length(pauli) ÷ L1)), ComplexF64}(pauli)
-function OperatorTS2D(op::Operator, L1::Integer; full = true, periodic::NTuple{2, Bool} = (true, true))
+OperatorTS2D(pauli::AbstractString, L1::Integer) = Operator{periodicpaulistringtype((L1, length(pauli) ÷ L1)),ComplexF64}(pauli)
+function OperatorTS2D(op::Operator, L1::Integer; full=true, periodic::NTuple{2,Bool}=(true, true))
     L2 = qubitlength(op) ÷ L1
     if full && !is_ts(op, (L1, L2), periodic)
         error("o is not translation symmetric. If you want to initialize an OperatorTS1D only with its local part H_0, then set full=false")
@@ -360,7 +360,7 @@ function OperatorTS2D(op::Operator, L1::Integer; full = true, periodic::NTuple{2
         num_translations = Base.prod(L for (L, p) in zip((L1, L2), periodic) if p)
         op /= num_translations
     end
-    return OperatorTS{(L1, L2), periodic}(op)
+    return OperatorTS{(L1, L2),periodic}(op)
 end
 
 OperatorTS2D(op::OperatorTS) = typeof(op)(copy(op.strings), copy(op.coeffs))
@@ -369,13 +369,13 @@ OperatorTS2D(op::OperatorTS) = typeof(op)(copy(op.strings), copy(op.coeffs))
 """
 Initialize a zero 1D translation-invariant operator on `N` qubits.
 """
-OperatorTS1D(N::Integer) = OperatorTS1D{paulistringtype(N), ComplexF64}()
+OperatorTS1D(N::Integer) = OperatorTS1D{paulistringtype(N),ComplexF64}()
 
-function OperatorTS1D(N::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T <: Unsigned}
+function OperatorTS1D(N::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T<:Unsigned}
     length(v) == length(w) == length(coef) || error("v, w, and coef must have the same length")
     P = periodicpaulistringtype((N,))
     strings = P.(v, w)
-    return OperatorTS1D{P, ComplexF64}(strings, coef)
+    return OperatorTS1D{P,ComplexF64}(strings, coef)
 end
 
 """
@@ -386,7 +386,7 @@ Initialize a 1D translation invariant operator from an Operator
 Set full=true if passing \$O\$, an Operator that is supported on the whole chain (i.e converting from a translation symmetric [`Operator`](@ref))
 Set full=false if passing \$O_0\$,a local term o such that the full operator is \$O=\\sum_i o_i T_i(O_0)\$
 """
-function OperatorTS1D(o::Operator; full = true, periodic::Bool = true)
+function OperatorTS1D(o::Operator; full=true, periodic::Bool=true)
     if full && !is_ts(o, (qubitlength(o),), (periodic,))
         error("o is not translation symmetric. If you want to initialize an OperatorTS1D only with its local part H_0, then set full=false")
     end
@@ -396,10 +396,10 @@ function OperatorTS1D(o::Operator; full = true, periodic::Bool = true)
         num_translations = periodic ? qubitlength(o) : 1
         o /= num_translations
     end
-    return OperatorTS{(qubitlength(o),), (periodic,)}(o)
+    return OperatorTS{(qubitlength(o),),(periodic,)}(o)
 end
 
-function Operator(o::Operator{<:PauliStringTS}; rs = true)
+function Operator(o::Operator{<:PauliStringTS}; rs=true)
     Base.depwarn("Operator(o::OperatorTS; rs) is deprecated. If rs=false, use representative(o), if rs=true, use resum(o)", :Operator)
     rs && (o = resum(o))
     return Operator(copy(o.strings), copy(o.coeffs))

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -4,13 +4,13 @@
 Type representing a translation symmetric sum of a Pauli string. The tuple `Ls` specifies the period in each dimension.
 The tuple `Ps` specifies which dimensions are periodic (true) or open (false). By default all dimensions are periodic.
 """
-struct PauliStringTS{Ls,Ps,T<:Unsigned} <: AbstractPauliString
+struct PauliStringTS{Ls, Ps, T <: Unsigned} <: AbstractPauliString
     v::T
     w::T
 end
 
-periodicpaulistringtype(Ls::NTuple{<:Any,Integer}) = PauliStringTS{Ls,ntuple(i -> true, length(Ls)),uinttype(Base.prod(Ls))}
-periodicpaulistringtype(Ls::NTuple{<:Any,Integer}, Ps::NTuple{<:Any,Bool}) = PauliStringTS{Ls,Ps,uinttype(Base.prod(Ls))}
+periodicpaulistringtype(Ls::NTuple{<:Any, Integer}) = PauliStringTS{Ls, ntuple(i -> true, length(Ls)), uinttype(Base.prod(Ls))}
+periodicpaulistringtype(Ls::NTuple{<:Any, Integer}, Ps::NTuple{<:Any, Bool}) = PauliStringTS{Ls, Ps, uinttype(Base.prod(Ls))}
 qubitlength(::Type{<:PauliStringTS{Ls}}) where {Ls} = Base.prod(Ls)
 
 """
@@ -28,7 +28,7 @@ qubitsize(p::PauliStringTS) = qubitsize(typeof(p))
 
 Get the tuple of periodic flags of a given `PauliStringTS`.
 """
-periodicflags(::Type{<:PauliStringTS{Ls,Ps}}) where {Ls,Ps} = Ps
+periodicflags(::Type{<:PauliStringTS{Ls, Ps}}) where {Ls, Ps} = Ps
 periodicflags(p::PauliStringTS) = periodicflags(typeof(p))
 
 for count in [:xcount, :ycount, :zcount, :pauli_weight]
@@ -45,7 +45,7 @@ function Base.string(p::PauliStringTS)
             return join(join.(eachcol(slice)), "\n")
         end
 
-        segments = str.(eachslice(slice, dims=((3:ndims(slice))...,)))
+        segments = str.(eachslice(slice, dims = ((3:ndims(slice))...,)))
 
         return join(["[:, :, $(join(Tuple(I), ", "))] =\n" * segments[I] for I in CartesianIndices(segments)], "\n\n")
     end
@@ -53,7 +53,7 @@ function Base.string(p::PauliStringTS)
     return str(σij)
 end
 
-Base.one(::Type{<:PauliStringTS{Ls,Ps,T}}) where {Ls,Ps,T} = PauliStringTS{Ls,Ps}(one(PauliString{Base.prod(Ls),T}))
+Base.one(::Type{<:PauliStringTS{Ls, Ps, T}}) where {Ls, Ps, T} = PauliStringTS{Ls, Ps}(one(PauliString{Base.prod(Ls), T}))
 Base.isless(a::PauliStringTS, b::PauliStringTS) = isless(representative(a), representative(b))
 
 """
@@ -64,10 +64,10 @@ Construct a translation symmetric sum of a Pauli string `p`. `Ls` is a tuple tha
 `Ps` is an optional tuple of Bool values indicating which dimensions are periodic (default: all true).
 """
 function PauliStringTS{Ls}(p::PauliString) where {Ls}
-    return PauliStringTS{Ls,ntuple(i -> true, length(Ls))}(p)
+    return PauliStringTS{Ls, ntuple(i -> true, length(Ls))}(p)
 end
 
-function PauliStringTS{Ls,Ps}(p::PauliString) where {Ls,Ps}
+function PauliStringTS{Ls, Ps}(p::PauliString) where {Ls, Ps}
     if !(Ls isa Tuple)
         error("Cannot construct PauliStringTS{$Ls}: $Ls is not a Tuple")
     end
@@ -84,7 +84,7 @@ function PauliStringTS{Ls,Ps}(p::PauliString) where {Ls,Ps}
     end
 
     rep = find_representative(p, Ls, Ps)
-    return PauliStringTS{Ls,Ps,typeof(rep.v)}(rep.v, rep.w)
+    return PauliStringTS{Ls, Ps, typeof(rep.v)}(rep.v, rep.w)
 end
 
 PauliStringTS{Ls}(pauli::AbstractString) where {Ls} = PauliStringTS{Ls}(PauliString(pauli))
@@ -95,7 +95,7 @@ PauliStringTS{Ls}(pauli::AbstractString) where {Ls} = PauliStringTS{Ls}(PauliStr
 
 Returns a unique representative string of the translation symmetric sum of the Pauli string `p`.
 """
-representative(p::PauliStringTS{Ls,Ps,T}) where {Ls,Ps,T} = PauliString{Base.prod(Ls),T}(p.v, p.w)
+representative(p::PauliStringTS{Ls, Ps, T}) where {Ls, Ps, T} = PauliString{Base.prod(Ls), T}(p.v, p.w)
 
 @inline function find_representative(p::PauliString, Ls)
     return find_representative(p, Ls, ntuple(i -> true, length(Ls)))
@@ -121,7 +121,7 @@ end
     # For each dimension, if periodic, generate all shifts 1:L, otherwise just 1 (identity)
     return Iterators.product(map((L, p) -> p ? (1:L) : (1:1), Ls, Ps)...)
 end
-@inline all_shifts(::Type{<:PauliStringTS{Ls,Ps}}) where {Ls,Ps} = all_shifts(Ls, Ps)
+@inline all_shifts(::Type{<:PauliStringTS{Ls, Ps}}) where {Ls, Ps} = all_shifts(Ls, Ps)
 
 """
     shift(p::PauliString, Ls::Tuple, shifts::Tuple)
@@ -132,11 +132,11 @@ end
 Interpret a PauliString as a multidimensional array whose size is given by the tuple `Ls` and apply a tuple of periodic `shifts` in the different dimensions to it.
 `Ps` is an optional tuple of Bool values indicating which dimensions are periodic (default: all true).
 """
-@inline shift(p::PauliString{N,T}, Ls::Tuple, shifts::Tuple) where {N,T} =
+@inline shift(p::PauliString{N, T}, Ls::Tuple, shifts::Tuple) where {N, T} =
     shift(p, Ls, ntuple(i -> true, length(Ls)), shifts)
 
-@inline shift(p::PauliString{N,T}, Ls::Tuple, Ps::Tuple, shifts::Tuple) where {N,T} =
-    PauliString{N,T}(_shift(p.v, Ls, Ps, shifts), _shift(p.w, Ls, Ps, shifts))
+@inline shift(p::PauliString{N, T}, Ls::Tuple, Ps::Tuple, shifts::Tuple) where {N, T} =
+    PauliString{N, T}(_shift(p.v, Ls, Ps, shifts), _shift(p.w, Ls, Ps, shifts))
 
 shift(p::Operator, Ls::Tuple, shifts::Tuple) = shift(p, Ls, ntuple(i -> true, length(Ls)), shifts)
 shift(p::Operator, Ls::Tuple, Ps::Tuple, shifts::Tuple) = Operator(shift.(p.strings, Ref(Ls), Ref(Ps), Ref(shifts)), copy(p.coeffs))
@@ -147,7 +147,7 @@ shift(p::Operator, Ls::Tuple, Ps::Tuple, shifts::Tuple) = Operator(shift.(p.stri
 
 Shift `p` by `r` bits, assuming it lives in 1D.
 """
-shift(p::Union{PauliString,Operator}, r::Integer) = shift(p, (qubitlength(p),), (r,))
+shift(p::Union{PauliString, Operator}, r::Integer) = shift(p, (qubitlength(p),), (r,))
 
 """
     _shift(x::Unsigned, Ls::Tuple, shifts::Tuple)
@@ -189,7 +189,7 @@ Periodically shift `x` by `s` bits within periodic windows of length `stride`.
     return (x << s) & (~(magicmask >> rshift)) | ((x & magicmask) >> rshift)
 end
 
-const OperatorTS{Ls,Ps,U,T} = Operator{PauliStringTS{Ls,Ps,U},T}
+const OperatorTS{Ls, Ps, U, T} = Operator{PauliStringTS{Ls, Ps, U}, T}
 
 @doc raw"""
     OperatorTS{Ls}(o::Operator)
@@ -207,13 +207,13 @@ where ``T`` are all translations on the `L1`×`L2`×… hypercube. So if you fee
 To get a dense operator from this lazy sum representation, see [`resum`](@ref). To get a single term, see [`representative`](@ref).
 """
 function OperatorTS{Ls}(o::Operator) where {Ls}
-    return OperatorTS{Ls,ntuple(i -> true, length(Ls))}(o)
+    return OperatorTS{Ls, ntuple(i -> true, length(Ls))}(o)
 end
 
-function OperatorTS{Ls,Ps}(o::Operator) where {Ls,Ps}
-    periodic_strings = PauliStringTS{Ls,Ps}.(o.strings)
+function OperatorTS{Ls, Ps}(o::Operator) where {Ls, Ps}
+    periodic_strings = PauliStringTS{Ls, Ps}.(o.strings)
     coeffs = copy(o.coeffs)
-    return compress(Operator{eltype(periodic_strings),eltype(coeffs)}(periodic_strings, coeffs))
+    return compress(Operator{eltype(periodic_strings), eltype(coeffs)}(periodic_strings, coeffs))
 end
 
 
@@ -221,7 +221,7 @@ OperatorTS{Ls}(pauli::PauliString) where {Ls} = OperatorTS{Ls}(Operator(pauli))
 function OperatorTS(pauli::PauliStringTS)
     periodic_strings = [pauli]
     coeffs = [1.0im^ycount(pauli)]
-    return compress(Operator{eltype(periodic_strings),eltype(coeffs)}(periodic_strings, coeffs))
+    return compress(Operator{eltype(periodic_strings), eltype(coeffs)}(periodic_strings, coeffs))
 end
 OperatorTS{Ls}(pauli::AbstractString) where {Ls} = OperatorTS{Ls}(PauliString(pauli))
 
@@ -229,7 +229,7 @@ OperatorTS{Ls}(pauli::AbstractString) where {Ls} = OperatorTS{Ls}(PauliString(pa
 qubitsize(::Type{<:OperatorTS{Ls}}) where {Ls} = Ls
 qubitsize(op::Operator{<:PauliStringTS}) = qubitsize(typeof(op))
 
-periodicflags(::Type{<:OperatorTS{Ls,Ps}}) where {Ls,Ps} = Ps
+periodicflags(::Type{<:OperatorTS{Ls, Ps}}) where {Ls, Ps} = Ps
 periodicflags(op::Operator{<:PauliStringTS}) = periodicflags(typeof(op))
 
 """
@@ -237,7 +237,7 @@ periodicflags(op::Operator{<:PauliStringTS}) = periodicflags(typeof(op))
 
 Returns a unique term of the symmetric sum represented by `o`.
 """
-representative(o::OperatorTS) = Operator(representative.(o.strings), copy(o.coeffs))
+representative(o::OperatorTS) = Operator(representative.(keys(o)), copy(values(o)))
 
 
 """
@@ -257,7 +257,7 @@ function resum(o::OperatorTS)
     return op
 end
 
-function binary_kernel(op, A::Operator{<:PauliStringTS}, B::Operator{<:PauliStringTS}; epsilon::Real=0, maxlength::Int=1000)
+function binary_kernel(op, A::Operator{<:PauliStringTS}, B::Operator{<:PauliStringTS}; epsilon::Real = 0, maxlength::Int = 1000)
     checklength(A, B)
     Ls = qubitsize(A)
     Ps = periodicflags(A)
@@ -271,15 +271,15 @@ function binary_kernel(op, A::Operator{<:PauliStringTS}, B::Operator{<:PauliStri
     length(p2s) == length(c2s) || throw(DimensionMismatch("strings and coefficients must have the same length"))
 
     # core kernel logic
-    @inbounds for (p1, c1) in zip(p1s, c1s)
+    @inbounds for (p1, c1) in pairs(A)
         rep1 = representative(p1)
-        for (p2, c2) in zip(p2s, c2s)
+        for (p2, c2) in pairs(B)
             rep2 = representative(p2)
             for s in all_shifts(paulistringtype(A))
                 p, k = op(rep1, shift(rep2, Ls, Ps, s))
                 c = c1 * c2 * k
                 if (k != 0) && pauli_weight(p) < maxlength
-                    setwith!(+, d, PauliStringTS{Ls,Ps}(p), c)
+                    setwith!(+, d, PauliStringTS{Ls, Ps}(p), c)
                 end
             end
         end
@@ -292,7 +292,7 @@ end
 function trace(o::Operator{<:PauliStringTS})
     r = zero(scalartype(o))
 
-    for (p, c) in zip(o.strings, o.coeffs)
+    for (p, c) in pairs(o)
         if isone(representative(p))
             r += c
         end
@@ -301,12 +301,12 @@ function trace(o::Operator{<:PauliStringTS})
     Ls = qubitsize(o)
     Ps = periodicflags(o)
     num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
-    return r * num_translations * 2^qubitlength(o)
+    return r * num_translations * 2.0^qubitlength(o)
 end
 
 Base.@deprecate opnorm(o::Operator{<:PauliStringTS}) LinearAlgebra.norm(o::Operator{<:PauliStringTS})
 
-function LinearAlgebra.norm(o::Operator{<:PauliStringTS}; normalize=false)
+function LinearAlgebra.norm(o::Operator{<:PauliStringTS}; normalize = false)
     n = sqrt(real(trace_product(o', o)))
     if normalize
         return n / (2.0^(qubitlength(o) / 2))
@@ -315,7 +315,7 @@ function LinearAlgebra.norm(o::Operator{<:PauliStringTS}; normalize=false)
     end
 end
 
-function LinearAlgebra.norm(p::PauliStringTS; normalize=false)
+function LinearAlgebra.norm(p::PauliStringTS; normalize = false)
     normalize && return sqrt(qubitlength(p))
     return sqrt(2.0^qubitlength(p) * qubitlength(p))
 end
@@ -352,7 +352,7 @@ return true if `o` is translation symmetric on a rectangle with sidelengths `L1`
 `Ps` is an optional tuple of Bool values indicating which dimensions are periodic (default: both true).
 """
 is_ts2d(o, L1) = is_ts(o, (L1, qubitlength(o) ÷ L1), (true, true))
-is_ts2d(o, L1, Ps::NTuple{2,Bool}) = is_ts(o, (L1, qubitlength(o) ÷ L1), Ps)
+is_ts2d(o, L1, Ps::NTuple{2, Bool}) = is_ts(o, (L1, qubitlength(o) ÷ L1), Ps)
 
 
 Base.:+(a::Number, o::Operator{<:PauliStringTS}) = begin
@@ -360,7 +360,7 @@ Base.:+(a::Number, o::Operator{<:PauliStringTS}) = begin
     Ls = qubitsize(o)
     Ps = periodicflags(o)
     num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
-    OperatorTS{qubitsize(o),periodicflags(o)}(representative(o) + a / num_translations)
+    OperatorTS{qubitsize(o), periodicflags(o)}(representative(o) + a / num_translations)
 end
 Base.:+(o::Operator{<:PauliStringTS}, a::Number) = a + o
 
@@ -371,17 +371,17 @@ Base.:+(o::Operator{<:PauliStringTS}, a::Number) = a + o
 
 Initialize a zero 2D translation-invariant operator on `N` qubits, with extent of `L1` in the ``a_1`` direction.
 """
-OperatorTS2D(N::Integer, L1::Integer) = (N % L1 == 0) ? Operator{periodicpaulistringtype((L1, N ÷ L1)),ComplexF64}() : error("N must be divisible by L1")
+OperatorTS2D(N::Integer, L1::Integer) = (N % L1 == 0) ? Operator{periodicpaulistringtype((L1, N ÷ L1)), ComplexF64}() : error("N must be divisible by L1")
 
-function OperatorTS2D(N::Int, L1::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T<:Unsigned}
+function OperatorTS2D(N::Int, L1::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T <: Unsigned}
     length(v) == length(w) == length(coef) || error("v, w, and coef must have the same length")
     P = periodicpaulistringtype((L1, N ÷ L1))
     strings = P.(v, w)
     return Operator(strings, coef)
 end
 
-OperatorTS2D(pauli::AbstractString, L1::Integer) = Operator{periodicpaulistringtype((L1, length(pauli) ÷ L1)),ComplexF64}(pauli)
-function OperatorTS2D(op::Operator, L1::Integer; full=true, periodic::NTuple{2,Bool}=(true, true))
+OperatorTS2D(pauli::AbstractString, L1::Integer) = Operator{periodicpaulistringtype((L1, length(pauli) ÷ L1)), ComplexF64}(pauli)
+function OperatorTS2D(op::Operator, L1::Integer; full = true, periodic::NTuple{2, Bool} = (true, true))
     L2 = qubitlength(op) ÷ L1
     if full && !is_ts(op, (L1, L2), periodic)
         error("o is not translation symmetric. If you want to initialize an OperatorTS1D only with its local part H_0, then set full=false")
@@ -392,7 +392,7 @@ function OperatorTS2D(op::Operator, L1::Integer; full=true, periodic::NTuple{2,B
         num_translations = Base.prod(L for (L, p) in zip((L1, L2), periodic) if p)
         op /= num_translations
     end
-    return OperatorTS{(L1, L2),periodic}(op)
+    return OperatorTS{(L1, L2), periodic}(op)
 end
 
 OperatorTS2D(op::OperatorTS) = typeof(op)(copy(op.strings), copy(op.coeffs))
@@ -401,13 +401,13 @@ OperatorTS2D(op::OperatorTS) = typeof(op)(copy(op.strings), copy(op.coeffs))
 """
 Initialize a zero 1D translation-invariant operator on `N` qubits.
 """
-OperatorTS1D(N::Integer) = OperatorTS1D{paulistringtype(N),ComplexF64}()
+OperatorTS1D(N::Integer) = OperatorTS1D{paulistringtype(N), ComplexF64}()
 
-function OperatorTS1D(N::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T<:Unsigned}
+function OperatorTS1D(N::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T <: Unsigned}
     length(v) == length(w) == length(coef) || error("v, w, and coef must have the same length")
     P = periodicpaulistringtype((N,))
     strings = P.(v, w)
-    return OperatorTS1D{P,ComplexF64}(strings, coef)
+    return OperatorTS1D{P, ComplexF64}(strings, coef)
 end
 
 """
@@ -418,7 +418,7 @@ Initialize a 1D translation invariant operator from an Operator
 Set full=true if passing \$O\$, an Operator that is supported on the whole chain (i.e converting from a translation symmetric [`Operator`](@ref))
 Set full=false if passing \$O_0\$,a local term o such that the full operator is \$O=\\sum_i o_i T_i(O_0)\$
 """
-function OperatorTS1D(o::Operator; full=true, periodic::Bool=true)
+function OperatorTS1D(o::Operator; full = true, periodic::Bool = true)
     if full && !is_ts(o, (qubitlength(o),), (periodic,))
         error("o is not translation symmetric. If you want to initialize an OperatorTS1D only with its local part H_0, then set full=false")
     end
@@ -428,10 +428,10 @@ function OperatorTS1D(o::Operator; full=true, periodic::Bool=true)
         num_translations = periodic ? qubitlength(o) : 1
         o /= num_translations
     end
-    return OperatorTS{(qubitlength(o),),(periodic,)}(o)
+    return OperatorTS{(qubitlength(o),), (periodic,)}(o)
 end
 
-function Operator(o::Operator{<:PauliStringTS}; rs=true)
+function Operator(o::Operator{<:PauliStringTS}; rs = true)
     Base.depwarn("Operator(o::OperatorTS; rs) is deprecated. If rs=false, use representative(o), if rs=true, use resum(o)", :Operator)
     rs && (o = resum(o))
     return Operator(copy(o.strings), copy(o.coeffs))

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -257,38 +257,6 @@ function resum(o::OperatorTS)
     return op
 end
 
-function binary_kernel(op, A::Operator{<:PauliStringTS}, B::Operator{<:PauliStringTS}; epsilon::Real = 0, maxlength::Int = 1000)
-    checklength(A, B)
-    Ls = qubitsize(A)
-    Ps = periodicflags(A)
-
-    d = emptydict(A)
-    p1s, c1s = A.strings, A.coeffs
-    p2s, c2s = B.strings, B.coeffs
-
-    # check lengths to safely use `@inbounds`
-    length(p1s) == length(c1s) || throw(DimensionMismatch("strings and coefficients must have the same length"))
-    length(p2s) == length(c2s) || throw(DimensionMismatch("strings and coefficients must have the same length"))
-
-    # core kernel logic
-    @inbounds for (p1, c1) in pairs(A)
-        rep1 = representative(p1)
-        for (p2, c2) in pairs(B)
-            rep2 = representative(p2)
-            for s in all_shifts(paulistringtype(A))
-                p, k = op(rep1, shift(rep2, Ls, Ps, s))
-                c = c1 * c2 * k
-                if (k != 0) && pauli_weight(p) < maxlength
-                    setwith!(+, d, PauliStringTS{Ls, Ps}(p), c)
-                end
-            end
-        end
-    end
-
-    o = typeof(A)(collect(keys(d)), collect(values(d)))
-    return (eltype(o.coeffs) == ComplexF64) ? cutoff(o, epsilon) : o
-end
-
 function trace(o::Operator{<:PauliStringTS})
     r = zero(scalartype(o))
 

--- a/src/trotter.jl
+++ b/src/trotter.jl
@@ -5,7 +5,7 @@ One factor in a product-form Trotter step: on each Pauli string, the Heisenberg 
 `exp(im * theta * G/2) * P * exp(-im * theta * G/2)` with generator `G`, implemented via [`pauli_rotation`](@ref).
 The `theta` field follows that convention.
 """
-struct TrotterGate{P<:AbstractPauliString,T<:Real}
+struct TrotterGate{P <: AbstractPauliString, T <: Real}
     generator::P
     theta::T
 end
@@ -18,8 +18,8 @@ function _trotter_theta(coeff::Number, dt::Real, hbar::Real, heisenberg::Bool)
 end
 
 function _lie_gates(H::Operator, dt::Real, hbar::Real, heisenberg::Bool)
-    gates = TrotterGate{paulistringtype(H),Float64}[]
-    for (c, p) in zip(get_coeffs(H), H.strings)
+    gates = TrotterGate{paulistringtype(H), Float64}[]
+    for (c, p) in zip(get_coeffs(H), keys(H))
         push!(gates, TrotterGate(p, _trotter_theta(c, dt, hbar, heisenberg)))
     end
     return gates
@@ -28,7 +28,7 @@ end
 
 function _strang_gates(H::Operator, dt::Real, hbar::Real, heisenberg::Bool)
     L = length(H)
-    gates = TrotterGate{paulistringtype(H),Float64}[]
+    gates = TrotterGate{paulistringtype(H), Float64}[]
     for j in 1:(L - 1)
         c, p = H[j]
         push!(gates, TrotterGate(p, _trotter_theta(c, dt, hbar, heisenberg) / 2))
@@ -51,12 +51,12 @@ Each gate uses [`pauli_rotation`](@ref) with the returned `theta` field.
 
 For `H::Operator{<:PauliStringTS}`, see the specialized [`trotterize`](@ref) that calls [`resum`](@ref) first.
 """
-function trotterize(H::Operator, dt::Real; order::Integer=2, heisenberg::Bool=true, hbar::Real=1)
+function trotterize(H::Operator, dt::Real; order::Integer = 2, heisenberg::Bool = true, hbar::Real = 1)
     order ∈ (1, 2) || throw(ArgumentError("order must be 1 or 2, got $order"))
     n = qubitlength(H)
-    norm(H - H') > 1e-10 && throw(ArgumentError("Hamiltonian must be Hermitian for Trotter splitting"))
+    norm(H - H') > 1.0e-10 && throw(ArgumentError("Hamiltonian must be Hermitian for Trotter splitting"))
     if length(H) == 0
-        return TrotterGate{paulistringtype(n),Float64}[]
+        return TrotterGate{paulistringtype(n), Float64}[]
     end
     if order == 1 || length(H) == 1
         return _lie_gates(H, dt, hbar, heisenberg)
@@ -72,7 +72,7 @@ Apply one Trotter step in place. Gates must be listed in matrix-multiply order `
 conjugation `O -> U * O * U'` applies factors `Vn, ..., V1` successively (reverse of the list).
 Each Pauli string uses the same coefficient convention as [`Matrix`](@ref)(`O`) (weights include division by `im` to the number of `Y` factors).
 """
-function trotter_step!(O::Operator, gates::AbstractVector{<:TrotterGate}; truncation::Function=identity, truncate_every::Int=1)
+function trotter_step!(O::Operator, gates::AbstractVector{<:TrotterGate}; truncation::Function = identity, truncate_every::Int = 1)
     isempty(gates) && return O
     N = qubitlength(O)
     d = emptydict(O)
@@ -83,13 +83,13 @@ function trotter_step!(O::Operator, gates::AbstractVector{<:TrotterGate}; trunca
         G = g.generator
         stheta, ctheta = sincos(g.theta)
         phase = (1.0im)^ycount(G)
-        for (P, c) in zip(O.strings, O.coeffs)
+        for (P, c) in pairs(O)
             C, k = commutator(G, P)
-            setwith!(+, d, P, c)# [G, P] as an Operator                     # commuting case
+            setwith!(+, d, P, c) # [G, P] as an Operator                     # commuting case
             if k != 0
                 # these are much smaller
-                setwith!(+, d, P, c*ctheta-c)
-                setwith!(+, d, C, c*(1im * stheta / 2) * phase*k )
+                setwith!(+, d, P, c * ctheta - c)
+                setwith!(+, d, C, c * (1im * stheta / 2) * phase * k)
             end
         end
         ks = Vector{keytype(d)}(undef, length(d))
@@ -98,8 +98,8 @@ function trotter_step!(O::Operator, gates::AbstractVector{<:TrotterGate}; trunca
             @inbounds ks[j] = k
             @inbounds vs[j] = v
         end
-        O2 = Operator{keytype(d),valtype(d)}(ks, vs)
-        (i%truncate_every == 0) && (O2 = truncation(O2))
+        O2 = Operator{keytype(d), valtype(d)}(ks, vs)
+        (i % truncate_every == 0) && (O2 = truncation(O2))
         empty!(O.strings)
         empty!(O.coeffs)
         append!(O.strings, O2.strings)

--- a/src/trotter.jl
+++ b/src/trotter.jl
@@ -5,7 +5,7 @@ One factor in a product-form Trotter step: on each Pauli string, the Heisenberg 
 `exp(im * theta * G/2) * P * exp(-im * theta * G/2)` with generator `G`, implemented via [`pauli_rotation`](@ref).
 The `theta` field follows that convention.
 """
-struct TrotterGate{P <: AbstractPauliString, T <: Real}
+struct TrotterGate{P<:AbstractPauliString,T<:Real}
     generator::P
     theta::T
 end
@@ -18,7 +18,7 @@ function _trotter_theta(coeff::Number, dt::Real, hbar::Real, heisenberg::Bool)
 end
 
 function _lie_gates(H::Operator, dt::Real, hbar::Real, heisenberg::Bool)
-    gates = TrotterGate{paulistringtype(H), Float64}[]
+    gates = TrotterGate{paulistringtype(H),Float64}[]
     for (c, p) in zip(get_coeffs(H), keys(H))
         push!(gates, TrotterGate(p, _trotter_theta(c, dt, hbar, heisenberg)))
     end
@@ -28,7 +28,7 @@ end
 
 function _strang_gates(H::Operator, dt::Real, hbar::Real, heisenberg::Bool)
     L = length(H)
-    gates = TrotterGate{paulistringtype(H), Float64}[]
+    gates = TrotterGate{paulistringtype(H),Float64}[]
     for j in 1:(L - 1)
         c, p = H[j]
         push!(gates, TrotterGate(p, _trotter_theta(c, dt, hbar, heisenberg) / 2))
@@ -51,12 +51,12 @@ Each gate uses [`pauli_rotation`](@ref) with the returned `theta` field.
 
 For `H::Operator{<:PauliStringTS}`, see the specialized [`trotterize`](@ref) that calls [`resum`](@ref) first.
 """
-function trotterize(H::Operator, dt::Real; order::Integer = 2, heisenberg::Bool = true, hbar::Real = 1)
+function trotterize(H::Operator, dt::Real; order::Integer=2, heisenberg::Bool=true, hbar::Real=1)
     order ∈ (1, 2) || throw(ArgumentError("order must be 1 or 2, got $order"))
     n = qubitlength(H)
-    norm(H - H') > 1.0e-10 && throw(ArgumentError("Hamiltonian must be Hermitian for Trotter splitting"))
+    norm(H - H') > 1e-10 && throw(ArgumentError("Hamiltonian must be Hermitian for Trotter splitting"))
     if length(H) == 0
-        return TrotterGate{paulistringtype(n), Float64}[]
+        return TrotterGate{paulistringtype(n),Float64}[]
     end
     if order == 1 || length(H) == 1
         return _lie_gates(H, dt, hbar, heisenberg)
@@ -72,7 +72,7 @@ Apply one Trotter step in place. Gates must be listed in matrix-multiply order `
 conjugation `O -> U * O * U'` applies factors `Vn, ..., V1` successively (reverse of the list).
 Each Pauli string uses the same coefficient convention as [`Matrix`](@ref)(`O`) (weights include division by `im` to the number of `Y` factors).
 """
-function trotter_step!(O::Operator, gates::AbstractVector{<:TrotterGate}; truncation::Function = identity, truncate_every::Int = 1)
+function trotter_step!(O::Operator, gates::AbstractVector{<:TrotterGate}; truncation::Function=identity, truncate_every::Int=1)
     isempty(gates) && return O
     N = qubitlength(O)
     d = emptydict(O)
@@ -85,11 +85,11 @@ function trotter_step!(O::Operator, gates::AbstractVector{<:TrotterGate}; trunca
         phase = (1.0im)^ycount(G)
         for (P, c) in pairs(O)
             C, k = commutator(G, P)
-            setwith!(+, d, P, c) # [G, P] as an Operator                     # commuting case
+            setwith!(+, d, P, c)# [G, P] as an Operator                     # commuting case
             if k != 0
                 # these are much smaller
-                setwith!(+, d, P, c * ctheta - c)
-                setwith!(+, d, C, c * (1im * stheta / 2) * phase * k)
+                setwith!(+, d, P, c*ctheta-c)
+                setwith!(+, d, C, c*(1im * stheta / 2) * phase*k )
             end
         end
         ks = Vector{keytype(d)}(undef, length(d))
@@ -98,8 +98,8 @@ function trotter_step!(O::Operator, gates::AbstractVector{<:TrotterGate}; trunca
             @inbounds ks[j] = k
             @inbounds vs[j] = v
         end
-        O2 = Operator{keytype(d), valtype(d)}(ks, vs)
-        (i % truncate_every == 0) && (O2 = truncation(O2))
+        O2 = Operator{keytype(d),valtype(d)}(ks, vs)
+        (i%truncate_every == 0) && (O2 = truncation(O2))
         empty!(O.strings)
         empty!(O.coeffs)
         append!(O.strings, O2.strings)

--- a/src/truncation.jl
+++ b/src/truncation.jl
@@ -22,14 +22,15 @@ julia> ps.truncate(A,2)
 ```
 """
 function PauliStrings.truncate(o::AbstractOperator, max_lenght::Int; keepnorm::Bool=false)
-    o2 = typeof(o)()
-    for i in 1:length(o)
-        p = o.strings[i]
+    ks = paulistringtype(o)[]
+    vs = scalartype(o)[]
+    for (p, c) in pairs(o)
         if pauli_weight(p) <= max_lenght
-            push!(o2.coeffs, o.coeffs[i])
-            push!(o2.strings, p)
+            push!(ks, p)
+            push!(vs, c)
         end
     end
+    o2 = typeof(o)(ks, vs)
     if keepnorm
         return o2 * norm(o) / norm(o2)
     end
@@ -62,16 +63,16 @@ julia> k_local_part(A,2)
 ```
 """
 function k_local_part(o::AbstractOperator, k::Int; atmost=false)
-    o2 = typeof(o)()
-    for i in 1:length(o)
-        p = o.strings[i]
+    ks = paulistringtype(o)[]
+    vs = scalartype(o)[]
+    for (p, c) in pairs(o)
         l = pauli_weight(p)
         if l == k || (atmost && l <= k)
-            push!(o2.coeffs, o.coeffs[i])
-            push!(o2.strings, p)
+            push!(ks, p)
+            push!(vs, c)
         end
     end
-    return o2
+    return typeof(o)(ks, vs)
 end
 
 
@@ -112,21 +113,23 @@ function trim(o::AbstractOperator, max_strings::Int; keepnorm::Bool=false, keep:
     if length(o) <= max_strings
         return deepcopy(o)
     end
+    # position-aligned strings/coeffs
+    ks = collect(keys(o))
+    vs = collect(values(o))
     # keep the N first indices
-    i = collect(partialsortperm(abs.(o.coeffs), 1:max_strings; rev=true))
+    i = collect(partialsortperm(abs.(vs), 1:max_strings; rev=true))
     # add the string to keep in case there was a specified string to keep
     if length(keep) > 0
-        for tau in 1:length(keep) #for each string tau in the keep operator
-            # we check if tau is in o and has been removed
-            p_keep = keep.strings[tau]
-            j = findfirst(==(p_keep), o.strings)
+        for p_keep in keys(keep) # for each string in the keep operator
+            # we check if it is in o and has been removed
+            j = findfirst(==(p_keep), ks)
             if !isnothing(j) && !(j in i)
                 push!(i, j)
             end
         end
     end
 
-    o1 = typeof(o)(o.strings[i], o.coeffs[i])
+    o1 = typeof(o)(ks[i], vs[i])
 
     if keepnorm
         return o1 * norm(o) / norm(o1)
@@ -140,14 +143,16 @@ end
 Keep terms with probability 1-exp(-alpha*abs(c)) where c is the weight of the term
 """
 function prune(o::AbstractOperator, alpha::Real; keepnorm::Bool=false)
-    i = Int[]
-    for k in 1:length(o)
-        p = 1 - exp(-alpha * abs(o.coeffs[k]))
+    ks = paulistringtype(o)[]
+    vs = scalartype(o)[]
+    for (s, c) in pairs(o)
+        p = 1 - exp(-alpha * abs(c))
         if rand() < p
-            push!(i, k)
+            push!(ks, s)
+            push!(vs, c)
         end
     end
-    o1 = typeof(o)(o.strings[i], o.coeffs[i])
+    o1 = typeof(o)(ks, vs)
     if keepnorm
         return o1 * norm(o) / norm(o1)
     end
@@ -174,13 +179,15 @@ julia> cutoff(A, 2.5)
 ```
 """
 function cutoff(o::AbstractOperator, epsilon::Real; keepnorm::Bool=false)
-    o2 = zero(o)
-    for i in 1:length(o)
-        if abs(o.coeffs[i]) > epsilon
-            push!(o2.coeffs, o.coeffs[i])
-            push!(o2.strings, o.strings[i])
+    ks = paulistringtype(o)[]
+    vs = scalartype(o)[]
+    for (p, c) in pairs(o)
+        if abs(c) > epsilon
+            push!(ks, p)
+            push!(vs, c)
         end
     end
+    o2 = typeof(o)(ks, vs)
     if keepnorm
         return o2 * norm(o) / norm(o2)
     end
@@ -208,8 +215,15 @@ zpart(o::AbstractOperator) = diag(o)
 Keep strings with only X and identity
 """
 function xpart(o::AbstractOperator)
-    I = findall(p -> zcount(p) == 0 && ycount(p) == 0, o.strings)
-    return typeof(o)(o.strings[I], o.coeffs[I])
+    ks = paulistringtype(o)[]
+    vs = scalartype(o)[]
+    for (p, c) in pairs(o)
+        if zcount(p) == 0 && ycount(p) == 0
+            push!(ks, p)
+            push!(vs, c)
+        end
+    end
+    return typeof(o)(ks, vs)
 end
 
 
@@ -219,6 +233,13 @@ end
 Keep strings with only Y and identity
 """
 function ypart(o::AbstractOperator)
-    I = findall(p -> zcount(p) == 0 && xcount(p) == 0, o.strings)
-    return typeof(o)(o.strings[I], o.coeffs[I])
+    ks = paulistringtype(o)[]
+    vs = scalartype(o)[]
+    for (p, c) in pairs(o)
+        if zcount(p) == 0 && xcount(p) == 0
+            push!(ks, p)
+            push!(vs, c)
+        end
+    end
+    return typeof(o)(ks, vs)
 end


### PR DESCRIPTION
This PR merges some of the kernel implementations together by making use of the general `keys`, `values` and `pairs` functions to provide iterators over the strings, coefficients, and their combination respectively.
The main point is that this can be used to make the kernels agnostic about whether the inputs are operators or single strings.

A secondary benefit (which is why I got to this in the first place) is that it makes the `AbstractOperator` implementations work out of the box for new operator types that provide this very minimal interface, making it easy to experiment and benchmark with e.g. storing strings in dictionaries instead of vectors.