### PR TITLE
Inplace kernels to reduce allocations

### DIFF
--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -1,4 +1,4 @@
-norm_lanczos(O::AbstractOperator) = norm(O, normalize=true)
+norm_lanczos(O::AbstractOperator) = norm(O, normalize = true)
 
 """
     lanczos(H::Operator, O::Operator, steps::Int, nterms::Int; keepnorm=true, maxlength=1000, returnOn=false)
@@ -12,32 +12,41 @@ Using `maxlength` speeds up the commutator by only keeping terms of length <= `m
 Set `returnOn=true` to save the On's at each step. Then the function returns a pair of lists (bn, On).
 The first operators of the list On is O
 """
-function lanczos(H::AbstractOperator, O::AbstractOperator, steps::Int, nterms::Int; keepnorm=true, maxlength=1000, returnOn=false, observer=false, show_progress=true)
+function lanczos(H::AbstractOperator, O::AbstractOperator, steps::Int, nterms::Int; keepnorm = true, maxlength = 1000, returnOn = false, observer = false, show_progress = true)
     @assert typeof(H) == typeof(O)
     checklength(H, O)
     @assert observer === false || returnOn === false
-    O0 = deepcopy(O)
-    O0 /= norm_lanczos(O0)
-    LHO = commutator(H, O0)
-    b = norm_lanczos(LHO)
-    O1 = commutator(H, O0) / b
-    bs = [b]
-    returnOn && (Ons = [O0, O1])
-    (observer !== false) && (obs = [observer(O0), observer(O1)])
-    progress = collect
-    show_progress && (progress = ProgressBar)
-    for n in progress(0:steps-2)
-        LHO = commutator(H, O1; maxlength=maxlength)
-        O2 = LHO - b * O0
-        b = norm_lanczos(O2)
-        O2 /= b
-        O2 = trim(O2, nterms; keepnorm=keepnorm)
-        returnOn && push!(Ons, O2)
-        (observer !== false) && push!(obs, observer(O2))
-        O0 = deepcopy(O1)
-        O1 = deepcopy(O2)
-        push!(bs, b)
+
+    # Ôₙ₋₁ starts as Ô₀ = O / ‖O‖.
+    Ôₙ₋₁ = scale(O, inv(norm_lanczos(O)))
+
+    Ôₙ = commutator(H, Ôₙ₋₁)
+    bₙ = norm_lanczos(Ôₙ)
+    Ôₙ = scale!(Ôₙ, inv(bₙ))
+
+    bs = [bₙ]
+    returnOn && (Ons = [copy(Ôₙ₋₁), copy(Ôₙ)])
+    (observer !== false) && (obs = [observer(Ôₙ₋₁), observer(Ôₙ)])
+
+    progress = show_progress ? ProgressBar : identity
+    for n in progress(0:(steps - 2))
+        # Lanczos three-term recurrence:
+        #   [H, Ôₙ] = bₙ₊₁ Ôₙ₊₁ + bₙ Ôₙ₋₁
+        #   ⟹ Ôₙ₊₁ = ([H, Ôₙ] − bₙ Ôₙ₋₁) / bₙ₊₁
+        bₙ₊₁Ôₙ₊₁ = commutator!(Ôₙ₋₁, H, Ôₙ, true, -bₙ; maxlength)
+        bₙ₊₁ = norm_lanczos(bₙ₊₁Ôₙ₊₁)
+        Ôₙ₊₁ = scale!(bₙ₊₁Ôₙ₊₁, inv(bₙ₊₁))
+        Ôₙ₊₁ = trim(Ôₙ₊₁, nterms; keepnorm)
+
+        returnOn && push!(Ons, copy(Ôₙ₊₁))
+        (observer !== false) && push!(obs, observer(Ôₙ₊₁))
+        push!(bs, bₙ₊₁)
+
+        # advance the window for the next step: bₙ ← bₙ₊₁ and (Ôₙ₋₁, Ôₙ) ← (Ôₙ, Ôₙ₊₁);
+        bₙ = bₙ₊₁
+        Ôₙ₋₁, Ôₙ = Ôₙ, Ôₙ₊₁
     end
+
     (observer !== false) && return (bs, obs)
     returnOn && (return bs, Ons)
     return bs

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -358,17 +358,19 @@ anticommutator(o1::Operator, o2::Number; kwargs...) = 2 * o1 * o2
 commutator(o1::Number, o2::Operator; kwargs...) = 0
 anticommutator(o1::Number, o2::Operator; kwargs...) = 2 * o1 * o2
 
+scale(o::Operator, a::Number) = scale!(copy(o), a)
+scale!(o::Operator, a::Number) = (values(o) .*= a; o)
 
-Base.:*(o::Operator, a::Number) = Operator(copy(o.strings), o.coeffs * a)
-Base.:*(a::Number, o::AbstractOperator) = o * a
+Base.:*(o::Operator, a::Number) = scale(o, a)
+Base.:*(a::Number, o::AbstractOperator) = scale(o, a)
 
 """
     Base.:/(o::AbstractOperator, a::Number)
 
 Divide an operator by a number
 """
-Base.:/(o::AbstractOperator, a::Number) = o * inv(a)
-Base.:\(a::Number, o::AbstractOperator) = o * inv(a)
+Base.:/(o::AbstractOperator, a::Number) = scale(o, inv(a))
+Base.:\(a::Number, o::AbstractOperator) = scale(o, inv(a))
 
 """
     prod(v1::Unsigned, w1::Unsigned, v2::Unsigned, w2::Unsigned) -> k, v, w

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -185,12 +185,35 @@ branch on `PauliStringTS` is resolved at compile time, so each variant compiles 
 fully-inlined loop. Terms with vanishing coefficient or Pauli weight `>= maxlength` are
 dropped, and the result is `cutoff` at `epsilon`.
 """
-function binary_kernel(f, A::AbstractOperator, B::AbstractOperator; maxlength::Int=1000, epsilon::Real=1e-16)
+function binary_kernel(f, A::AbstractOperator, B::AbstractOperator, α::Number = true; kwargs...)
     checklength(A, B)
 
     P = paulistringtype(A)
     T = complex(Base.promote_op(*, scalartype(A), scalartype(B)))
-    d = UnorderedDictionary{P,T}(; sizehint=max(length(A), length(B)))
+    C = Operator{P, T}()
+
+    return binary_kernel!(f, C, A, B, α; kwargs...)
+end
+
+
+_size_estimate(lC, lA, lB) = min(lC + lA * lB)
+
+function binary_kernel!(
+        f::F, C::AbstractOperator, A::AbstractOperator, B::AbstractOperator, α::Number = true, β::Number = false;
+        maxlength::Int = 1000, epsilon::Real = eps(real(scalartype(C)))
+    ) where {F}
+    checklength(C, A, B)
+
+    # Compute output scalartype
+    T = scalartype(C)
+    P = paulistringtype(C)
+    d = UnorderedDictionary{P, T}(; sizehint = _size_estimate(iszero(β) ? 0 : length(C), length(A), length(B)))
+    if !iszero(β)
+        @inbounds for (p, c) in pairs(C)
+            insert!(d, p, c * β)
+        end
+    end
+
     ksA, vsA = keys(A), values(A)
     ksB, vsB = keys(B), values(B)
 
@@ -198,31 +221,52 @@ function binary_kernel(f, A::AbstractOperator, B::AbstractOperator; maxlength::I
     if P <: PauliStringTS
         Ls, Ps = qubitsize(P), periodicflags(P)
         @inbounds for i in eachindex(ksA, vsA)
-            rep1, c1 = representative(ksA[i]), vsA[i]
+            rep1, c₁ = representative(ksA[i]), vsA[i]
+            αc₁ = α * c₁
             for j in eachindex(ksB, vsB)
-                rep2, c2 = representative(ksB[j]), vsB[j]
+                rep2, c₂ = representative(ksB[j]), vsB[j]
+                c = αc₁ * c₂
                 for s in all_shifts(Ls, Ps)
                     p, k = f(rep1, shift(rep2, Ls, Ps, s))
                     (iszero(k) || pauli_weight(p) >= maxlength) && continue
-                    setwith!(+, d, PauliStringTS{Ls,Ps}(p), c1 * c2 * k)
+                    setwith!(+, d, P(p), c * k)
                 end
             end
         end
     else
         @inbounds for i in eachindex(ksA, vsA)
-            p1, c1 = ksA[i], vsA[i]
+            p₁, c₁ = ksA[i], vsA[i]
             for j in eachindex(ksB, vsB)
-                p, k = f(p1, ksB[j])
+                p₂, c₂ = ksB[j], vsB[j]
+                p, k = f(p₁, p₂)
                 (iszero(k) || pauli_weight(p) >= maxlength) && continue
-                setwith!(+, d, p, c1 * vsB[j] * k)
+                setwith!(+, d, p, c₁ * c₂ * k)
             end
         end
     end
 
     # assemble output
-    o = Operator{P,T}(collect(keys(d)), collect(values(d)))
-    return cutoff(o, epsilon)
+    resize!(C, length(d))
+    ksC, vsC = keys(C), values(C)
+    if epsilon > 0
+        ϵ² = epsilon^2 # abs2 is faster than abs
+        i = 1
+        @inbounds for (p, c) in pairs(d)
+            ksC[i] = p
+            vsC[i] = c
+            i += abs2(c) > ϵ²
+        end
+        resize!(C, i - 1)
+    else
+        @inbounds for (i, (p, c)) in enumerate(pairs(d))
+            ksC[i] = p
+            vsC[i] = c
+        end
+    end
+
+    return C
 end
+
 
 """
     Base.:*(o1::Operator, o2::Operator; kwargs...)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -309,10 +309,13 @@ julia> A*5
 Base.:*(A::AbstractOperator, B::AbstractOperator; kwargs...) = binary_kernel(prod, A, B; kwargs...)
 
 
-"""
-    commutator(o1::Operator, o2::Operator; kwargs...)
+@doc """
+    commutator(A::AbstractOperator, B::AbstractOperator, [α::Number = true]; kwargs...)
+    commutator!(C::AbstractOperator, A::AbstractOperator, B::AbstractOperator, [α::Number = true, β::Number = false]; kwargs...)
 
-Commutator of two operators. This is faster than doing `o1*o2 - o2*o1`.
+Compute the commutator ``\\[A, B\\] = A ⋅ B - B ⋅ A`` in one go, avoiding forming the intermediate products.
+For expert usage, you can also use the in-place variant `commutator!`, to compute ``β ⋅ C + α ⋅ \\[A, B\\]`` and store the result in `C`.
+
 # Example
 ```
 julia> A = Operator(4)
@@ -323,19 +326,32 @@ julia> B += "XYZ1"
 julia> commutator(A,B)
 (0.0 - 2.0im) Y111
 ```
-"""
-commutator(A::AbstractOperator, B::AbstractOperator; kwargs...) = binary_kernel(commutator, A, B; kwargs...)
+
+See also [`anticommutator(!)`](@ref anticommutator).
+""" commutator, commutator!
+
+commutator(A::AbstractOperator, B::AbstractOperator, α::Number = true; kwargs...) =
+    binary_kernel(commutator, A, B, α; kwargs...)
+commutator!(C::AbstractOperator, A::AbstractOperator, B::AbstractOperator, α::Number = true, β::Number = false; kwargs...) =
+    binary_kernel!(commutator, C, A, B, α, β; kwargs...)
+
+@doc """
+    anticommutator(A::AbstractOperator, B::AbstractOperator, [α::Number = true]; kwargs...)
+    anticommutator!(C::AbstractOperator, A::AbstractOperator, B::AbstractOperator, [α::Number = true, β::Number = false]; kwargs...)
+
+Compute the anticommutator ``\\{A, B\\} = A ⋅ B + B ⋅ A`` in one go, avoiding forming the intermediate products.
+For expert usage, you can also use the in-place variant `anticommutator!`, to compute ``β ⋅ C + α ⋅ \\{A, B\\}`` and store the result in `C`.
+
+See also [`commutator(!)`](@ref commutator).
+""" anticommutator, anticommutator!
+
+anticommutator(A::AbstractOperator, B::AbstractOperator, α::Number = true; kwargs...) =
+    binary_kernel(anticommutator, A, B, α; kwargs...)
+anticommutator!(C::AbstractOperator, A::AbstractOperator, B::AbstractOperator, α::Number = true, β::Number = false; kwargs...) =
+    binary_kernel!(anticommutator, C, A, B, α, β; kwargs...)
 
 
-"""
-    anticommutator(o1::Operator, o2::Operator; kwargs...)
-
-Commutator of two operators. This is faster than doing `o1*o2 + o2*o1`.
-"""
-anticommutator(A::AbstractOperator, B::AbstractOperator; kwargs...) = binary_kernel(anticommutator, A, B; kwargs...)
-
-
-Base.@deprecate com(o1, o2; anti=false, kwargs...) (anti ? anticommutator : commutator)(o1, o2; kwargs...)
+Base.@deprecate com(o1, o2; anti = false, kwargs...) (anti ? anticommutator : commutator)(o1, o2; kwargs...)
 
 commutator(o1::Operator, o2::Number; kwargs...) = 0
 anticommutator(o1::Operator, o2::Number; kwargs...) = 2 * o1 * o2

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -240,11 +240,12 @@ function binary_kernel!(
     else
         @inbounds for i in eachindex(ksA, vsA)
             p₁, c₁ = ksA[i], vsA[i]
+            αc₁ = α * c₁
             for j in eachindex(ksB, vsB)
                 p₂, c₂ = ksB[j], vsB[j]
                 p, k = f(p₁, p₂)
                 (iszero(k) || pauli_weight(p) >= maxlength) && continue
-                setwith!(+, d, p, c₁ * c₂ * k)
+                setwith!(+, d, p, αc₁ * c₂ * k)
             end
         end
     end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -196,7 +196,11 @@ function binary_kernel(f, A::AbstractOperator, B::AbstractOperator, α::Number =
 end
 
 
-_size_estimate(lC, lA, lB) = min(lC + lA * lB)
+# Estimate the number of distinct output terms to size the accumulator dictionary.
+# The product lA*lB is the worst case (every pair contributes a distinct string), but is
+# almost never realized and grossly over-allocates; max(lA, lB) tracks the typical output
+# size and lets the dict rehash up if needed. lC covers the β·C terms pre-inserted below.
+_size_estimate(lC, lA, lB) = lC + max(lA, lB)
 
 function binary_kernel!(
         f::F, C::AbstractOperator, A::AbstractOperator, B::AbstractOperator, α::Number = true, β::Number = false;

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -104,6 +104,7 @@ julia> length(A)
 """
 Base.length(o::Union{Operator}) = length(keys(o))
 
+Base.resize!(o::Operator, L::Int; kwargs...) = (resize!(keys(o), L; kwargs...); resize!(values(o), L; kwargs...); o)
 
 """
     eye(N::Int)

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -126,6 +126,6 @@ Base.checkbounds(p::PauliString, i::Int) = checkbounds(Bool, p, i) || throw(Boun
 
 checklength(::Type{Bool}, o1::AbstractOperator) = true
 checklength(::Type{Bool}, o1::AbstractOperator, o2::AbstractOperator) = qubitlength(o1) == qubitlength(o2)
-checklength(::Type{Bool}, o1::AbstractOperator, o2::AbstractOperator...) = checklength(Bool, o1, first(o2)) & checklength(Bool, o1, tail(o2)...)
+checklength(::Type{Bool}, o1::AbstractOperator, o2::AbstractOperator...) = checklength(Bool, o1, first(o2)) & checklength(Bool, o1, Base.tail(o2)...)
 
 checklength(o1::AbstractOperator, o2::AbstractOperator...) = checklength(Bool, o1, o2...) || throw(DimensionMismatch("Operators must have the same number of qubits"))

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -63,11 +63,9 @@ Base.isless(a::PauliStringTS, b::PauliStringTS) = isless(representative(a), repr
 Construct a translation symmetric sum of a Pauli string `p`. `Ls` is a tuple that specifies the periodicity in each dimension.
 `Ps` is an optional tuple of Bool values indicating which dimensions are periodic (default: all true).
 """
-function PauliStringTS{Ls}(p::PauliString) where {Ls}
-    return PauliStringTS{Ls,ntuple(i -> true, length(Ls))}(p)
-end
-
-function PauliStringTS{Ls,Ps}(p::PauliString) where {Ls,Ps}
+PauliStringTS{Ls}(p::PauliString) where {Ls} = PauliStringTS{Ls, ntuple(Returns(true), length(Ls))}(p)
+PauliStringTS{Ls, Ps}(p::PauliString) where {Ls, Ps} = periodicpaulistringtype(Ls, Ps)(p)
+function PauliStringTS{Ls, Ps, T}(p::PauliString) where {Ls, Ps, T}
     if !(Ls isa Tuple)
         error("Cannot construct PauliStringTS{$Ls}: $Ls is not a Tuple")
     end
@@ -84,7 +82,7 @@ function PauliStringTS{Ls,Ps}(p::PauliString) where {Ls,Ps}
     end
 
     rep = find_representative(p, Ls, Ps)
-    return PauliStringTS{Ls,Ps,typeof(rep.v)}(rep.v, rep.w)
+    return PauliStringTS{Ls, Ps, T}(rep.v, rep.w)
 end
 
 PauliStringTS{Ls}(pauli::AbstractString) where {Ls} = PauliStringTS{Ls}(PauliString(pauli))

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -4,13 +4,13 @@
 Type representing a translation symmetric sum of a Pauli string. The tuple `Ls` specifies the period in each dimension.
 The tuple `Ps` specifies which dimensions are periodic (true) or open (false). By default all dimensions are periodic.
 """
-struct PauliStringTS{Ls,Ps,T<:Unsigned} <: AbstractPauliString
+struct PauliStringTS{Ls, Ps, T <: Unsigned} <: AbstractPauliString
     v::T
     w::T
 end
 
-periodicpaulistringtype(Ls::NTuple{<:Any,Integer}) = PauliStringTS{Ls,ntuple(i -> true, length(Ls)),uinttype(Base.prod(Ls))}
-periodicpaulistringtype(Ls::NTuple{<:Any,Integer}, Ps::NTuple{<:Any,Bool}) = PauliStringTS{Ls,Ps,uinttype(Base.prod(Ls))}
+periodicpaulistringtype(Ls::NTuple{<:Any, Integer}) = PauliStringTS{Ls, ntuple(i -> true, length(Ls)), uinttype(Base.prod(Ls))}
+periodicpaulistringtype(Ls::NTuple{<:Any, Integer}, Ps::NTuple{<:Any, Bool}) = PauliStringTS{Ls, Ps, uinttype(Base.prod(Ls))}
 qubitlength(::Type{<:PauliStringTS{Ls}}) where {Ls} = Base.prod(Ls)
 
 """
@@ -28,7 +28,7 @@ qubitsize(p::PauliStringTS) = qubitsize(typeof(p))
 
 Get the tuple of periodic flags of a given `PauliStringTS`.
 """
-periodicflags(::Type{<:PauliStringTS{Ls,Ps}}) where {Ls,Ps} = Ps
+periodicflags(::Type{<:PauliStringTS{Ls, Ps}}) where {Ls, Ps} = Ps
 periodicflags(p::PauliStringTS) = periodicflags(typeof(p))
 
 for count in [:xcount, :ycount, :zcount, :pauli_weight]
@@ -45,7 +45,7 @@ function Base.string(p::PauliStringTS)
             return join(join.(eachcol(slice)), "\n")
         end
 
-        segments = str.(eachslice(slice, dims=((3:ndims(slice))...,)))
+        segments = str.(eachslice(slice, dims = ((3:ndims(slice))...,)))
 
         return join(["[:, :, $(join(Tuple(I), ", "))] =\n" * segments[I] for I in CartesianIndices(segments)], "\n\n")
     end
@@ -53,7 +53,7 @@ function Base.string(p::PauliStringTS)
     return str(σij)
 end
 
-Base.one(::Type{<:PauliStringTS{Ls,Ps,T}}) where {Ls,Ps,T} = PauliStringTS{Ls,Ps}(one(PauliString{Base.prod(Ls),T}))
+Base.one(::Type{<:PauliStringTS{Ls, Ps, T}}) where {Ls, Ps, T} = PauliStringTS{Ls, Ps}(one(PauliString{Base.prod(Ls), T}))
 Base.isless(a::PauliStringTS, b::PauliStringTS) = isless(representative(a), representative(b))
 
 """
@@ -63,7 +63,7 @@ Base.isless(a::PauliStringTS, b::PauliStringTS) = isless(representative(a), repr
 Construct a translation symmetric sum of a Pauli string `p`. `Ls` is a tuple that specifies the periodicity in each dimension.
 `Ps` is an optional tuple of Bool values indicating which dimensions are periodic (default: all true).
 """
-PauliStringTS{Ls}(p::PauliString) where {Ls} = PauliStringTS{Ls, ntuple(Returns(true), length(Ls))}(p)
+PauliStringTS{Ls}(p::PauliString) where {Ls} = PauliStringTS{Ls, ntuple(_ -> true, length(Ls))}(p)
 PauliStringTS{Ls, Ps}(p::PauliString) where {Ls, Ps} = periodicpaulistringtype(Ls, Ps)(p)
 function PauliStringTS{Ls, Ps, T}(p::PauliString) where {Ls, Ps, T}
     if !(Ls isa Tuple)
@@ -86,8 +86,8 @@ function PauliStringTS{Ls, Ps, T}(p::PauliString) where {Ls, Ps, T}
 end
 
 PauliStringTS{Ls}(pauli::AbstractString) where {Ls} = PauliStringTS{Ls}(PauliString(pauli))
-PauliStringTS{Ls,Ps}(pauli::AbstractString) where {Ls,Ps} = PauliStringTS{Ls,Ps}(PauliString(pauli))
-PauliStringTS{Ls,Ps,T}(pauli::AbstractString) where {Ls,Ps,T} = PauliStringTS{Ls,Ps}(PauliString{Base.prod(Ls),T}(pauli))
+PauliStringTS{Ls, Ps}(pauli::AbstractString) where {Ls, Ps} = PauliStringTS{Ls, Ps}(PauliString(pauli))
+PauliStringTS{Ls, Ps, T}(pauli::AbstractString) where {Ls, Ps, T} = PauliStringTS{Ls, Ps}(PauliString{Base.prod(Ls), T}(pauli))
 
 
 """
@@ -95,7 +95,7 @@ PauliStringTS{Ls,Ps,T}(pauli::AbstractString) where {Ls,Ps,T} = PauliStringTS{Ls
 
 Returns a unique representative string of the translation symmetric sum of the Pauli string `p`.
 """
-representative(p::PauliStringTS{Ls,Ps,T}) where {Ls,Ps,T} = PauliString{Base.prod(Ls),T}(p.v, p.w)
+representative(p::PauliStringTS{Ls, Ps, T}) where {Ls, Ps, T} = PauliString{Base.prod(Ls), T}(p.v, p.w)
 
 @inline function find_representative(p::PauliString, Ls)
     return find_representative(p, Ls, ntuple(i -> true, length(Ls)))
@@ -121,7 +121,7 @@ end
     # For each dimension, if periodic, generate all shifts 1:L, otherwise just 1 (identity)
     return Iterators.product(map((L, p) -> p ? (1:L) : (1:1), Ls, Ps)...)
 end
-@inline all_shifts(::Type{<:PauliStringTS{Ls,Ps}}) where {Ls,Ps} = all_shifts(Ls, Ps)
+@inline all_shifts(::Type{<:PauliStringTS{Ls, Ps}}) where {Ls, Ps} = all_shifts(Ls, Ps)
 
 """
     shift(p::PauliString, Ls::Tuple, shifts::Tuple)
@@ -132,11 +132,11 @@ end
 Interpret a PauliString as a multidimensional array whose size is given by the tuple `Ls` and apply a tuple of periodic `shifts` in the different dimensions to it.
 `Ps` is an optional tuple of Bool values indicating which dimensions are periodic (default: all true).
 """
-@inline shift(p::PauliString{N,T}, Ls::Tuple, shifts::Tuple) where {N,T} =
+@inline shift(p::PauliString{N, T}, Ls::Tuple, shifts::Tuple) where {N, T} =
     shift(p, Ls, ntuple(i -> true, length(Ls)), shifts)
 
-@inline shift(p::PauliString{N,T}, Ls::Tuple, Ps::Tuple, shifts::Tuple) where {N,T} =
-    PauliString{N,T}(_shift(p.v, Ls, Ps, shifts), _shift(p.w, Ls, Ps, shifts))
+@inline shift(p::PauliString{N, T}, Ls::Tuple, Ps::Tuple, shifts::Tuple) where {N, T} =
+    PauliString{N, T}(_shift(p.v, Ls, Ps, shifts), _shift(p.w, Ls, Ps, shifts))
 
 shift(p::Operator, Ls::Tuple, shifts::Tuple) = shift(p, Ls, ntuple(i -> true, length(Ls)), shifts)
 shift(p::Operator, Ls::Tuple, Ps::Tuple, shifts::Tuple) = Operator(shift.(p.strings, Ref(Ls), Ref(Ps), Ref(shifts)), copy(p.coeffs))
@@ -147,7 +147,7 @@ shift(p::Operator, Ls::Tuple, Ps::Tuple, shifts::Tuple) = Operator(shift.(p.stri
 
 Shift `p` by `r` bits, assuming it lives in 1D.
 """
-shift(p::Union{PauliString,Operator}, r::Integer) = shift(p, (qubitlength(p),), (r,))
+shift(p::Union{PauliString, Operator}, r::Integer) = shift(p, (qubitlength(p),), (r,))
 
 """
     _shift(x::Unsigned, Ls::Tuple, shifts::Tuple)
@@ -189,7 +189,7 @@ Periodically shift `x` by `s` bits within periodic windows of length `stride`.
     return (x << s) & (~(magicmask >> rshift)) | ((x & magicmask) >> rshift)
 end
 
-const OperatorTS{Ls,Ps,U,T} = Operator{PauliStringTS{Ls,Ps,U},T}
+const OperatorTS{Ls, Ps, U, T} = Operator{PauliStringTS{Ls, Ps, U}, T}
 
 @doc raw"""
     OperatorTS{Ls}(o::Operator)
@@ -207,13 +207,13 @@ where ``T`` are all translations on the `L1`×`L2`×… hypercube. So if you fee
 To get a dense operator from this lazy sum representation, see [`resum`](@ref). To get a single term, see [`representative`](@ref).
 """
 function OperatorTS{Ls}(o::Operator) where {Ls}
-    return OperatorTS{Ls,ntuple(i -> true, length(Ls))}(o)
+    return OperatorTS{Ls, ntuple(i -> true, length(Ls))}(o)
 end
 
-function OperatorTS{Ls,Ps}(o::Operator) where {Ls,Ps}
-    periodic_strings = PauliStringTS{Ls,Ps}.(o.strings)
+function OperatorTS{Ls, Ps}(o::Operator) where {Ls, Ps}
+    periodic_strings = PauliStringTS{Ls, Ps}.(o.strings)
     coeffs = copy(o.coeffs)
-    return compress(Operator{eltype(periodic_strings),eltype(coeffs)}(periodic_strings, coeffs))
+    return compress(Operator{eltype(periodic_strings), eltype(coeffs)}(periodic_strings, coeffs))
 end
 
 
@@ -221,7 +221,7 @@ OperatorTS{Ls}(pauli::PauliString) where {Ls} = OperatorTS{Ls}(Operator(pauli))
 function OperatorTS(pauli::PauliStringTS)
     periodic_strings = [pauli]
     coeffs = [1.0im^ycount(pauli)]
-    return compress(Operator{eltype(periodic_strings),eltype(coeffs)}(periodic_strings, coeffs))
+    return compress(Operator{eltype(periodic_strings), eltype(coeffs)}(periodic_strings, coeffs))
 end
 OperatorTS{Ls}(pauli::AbstractString) where {Ls} = OperatorTS{Ls}(PauliString(pauli))
 
@@ -229,7 +229,7 @@ OperatorTS{Ls}(pauli::AbstractString) where {Ls} = OperatorTS{Ls}(PauliString(pa
 qubitsize(::Type{<:OperatorTS{Ls}}) where {Ls} = Ls
 qubitsize(op::Operator{<:PauliStringTS}) = qubitsize(typeof(op))
 
-periodicflags(::Type{<:OperatorTS{Ls,Ps}}) where {Ls,Ps} = Ps
+periodicflags(::Type{<:OperatorTS{Ls, Ps}}) where {Ls, Ps} = Ps
 periodicflags(op::Operator{<:PauliStringTS}) = periodicflags(typeof(op))
 
 """
@@ -274,7 +274,7 @@ end
 
 Base.@deprecate opnorm(o::Operator{<:PauliStringTS}) LinearAlgebra.norm(o::Operator{<:PauliStringTS})
 
-function LinearAlgebra.norm(o::Operator{<:PauliStringTS}; normalize=false)
+function LinearAlgebra.norm(o::Operator{<:PauliStringTS}; normalize = false)
     n = sqrt(real(trace_product(o', o)))
     if normalize
         return n / (2.0^(qubitlength(o) / 2))
@@ -283,7 +283,7 @@ function LinearAlgebra.norm(o::Operator{<:PauliStringTS}; normalize=false)
     end
 end
 
-function LinearAlgebra.norm(p::PauliStringTS; normalize=false)
+function LinearAlgebra.norm(p::PauliStringTS; normalize = false)
     normalize && return sqrt(qubitlength(p))
     return sqrt(2.0^qubitlength(p) * qubitlength(p))
 end
@@ -320,7 +320,7 @@ return true if `o` is translation symmetric on a rectangle with sidelengths `L1`
 `Ps` is an optional tuple of Bool values indicating which dimensions are periodic (default: both true).
 """
 is_ts2d(o, L1) = is_ts(o, (L1, qubitlength(o) ÷ L1), (true, true))
-is_ts2d(o, L1, Ps::NTuple{2,Bool}) = is_ts(o, (L1, qubitlength(o) ÷ L1), Ps)
+is_ts2d(o, L1, Ps::NTuple{2, Bool}) = is_ts(o, (L1, qubitlength(o) ÷ L1), Ps)
 
 
 Base.:+(a::Number, o::Operator{<:PauliStringTS}) = begin
@@ -328,7 +328,7 @@ Base.:+(a::Number, o::Operator{<:PauliStringTS}) = begin
     Ls = qubitsize(o)
     Ps = periodicflags(o)
     num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
-    OperatorTS{qubitsize(o),periodicflags(o)}(representative(o) + a / num_translations)
+    OperatorTS{qubitsize(o), periodicflags(o)}(representative(o) + a / num_translations)
 end
 Base.:+(o::Operator{<:PauliStringTS}, a::Number) = a + o
 
@@ -339,17 +339,17 @@ Base.:+(o::Operator{<:PauliStringTS}, a::Number) = a + o
 
 Initialize a zero 2D translation-invariant operator on `N` qubits, with extent of `L1` in the ``a_1`` direction.
 """
-OperatorTS2D(N::Integer, L1::Integer) = (N % L1 == 0) ? Operator{periodicpaulistringtype((L1, N ÷ L1)),ComplexF64}() : error("N must be divisible by L1")
+OperatorTS2D(N::Integer, L1::Integer) = (N % L1 == 0) ? Operator{periodicpaulistringtype((L1, N ÷ L1)), ComplexF64}() : error("N must be divisible by L1")
 
-function OperatorTS2D(N::Int, L1::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T<:Unsigned}
+function OperatorTS2D(N::Int, L1::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T <: Unsigned}
     length(v) == length(w) == length(coef) || error("v, w, and coef must have the same length")
     P = periodicpaulistringtype((L1, N ÷ L1))
     strings = P.(v, w)
     return Operator(strings, coef)
 end
 
-OperatorTS2D(pauli::AbstractString, L1::Integer) = Operator{periodicpaulistringtype((L1, length(pauli) ÷ L1)),ComplexF64}(pauli)
-function OperatorTS2D(op::Operator, L1::Integer; full=true, periodic::NTuple{2,Bool}=(true, true))
+OperatorTS2D(pauli::AbstractString, L1::Integer) = Operator{periodicpaulistringtype((L1, length(pauli) ÷ L1)), ComplexF64}(pauli)
+function OperatorTS2D(op::Operator, L1::Integer; full = true, periodic::NTuple{2, Bool} = (true, true))
     L2 = qubitlength(op) ÷ L1
     if full && !is_ts(op, (L1, L2), periodic)
         error("o is not translation symmetric. If you want to initialize an OperatorTS1D only with its local part H_0, then set full=false")
@@ -360,7 +360,7 @@ function OperatorTS2D(op::Operator, L1::Integer; full=true, periodic::NTuple{2,B
         num_translations = Base.prod(L for (L, p) in zip((L1, L2), periodic) if p)
         op /= num_translations
     end
-    return OperatorTS{(L1, L2),periodic}(op)
+    return OperatorTS{(L1, L2), periodic}(op)
 end
 
 OperatorTS2D(op::OperatorTS) = typeof(op)(copy(op.strings), copy(op.coeffs))
@@ -369,13 +369,13 @@ OperatorTS2D(op::OperatorTS) = typeof(op)(copy(op.strings), copy(op.coeffs))
 """
 Initialize a zero 1D translation-invariant operator on `N` qubits.
 """
-OperatorTS1D(N::Integer) = OperatorTS1D{paulistringtype(N),ComplexF64}()
+OperatorTS1D(N::Integer) = OperatorTS1D{paulistringtype(N), ComplexF64}()
 
-function OperatorTS1D(N::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T<:Unsigned}
+function OperatorTS1D(N::Int, v::Vector{T}, w::Vector{T}, coef::AbstractVector) where {T <: Unsigned}
     length(v) == length(w) == length(coef) || error("v, w, and coef must have the same length")
     P = periodicpaulistringtype((N,))
     strings = P.(v, w)
-    return OperatorTS1D{P,ComplexF64}(strings, coef)
+    return OperatorTS1D{P, ComplexF64}(strings, coef)
 end
 
 """
@@ -386,7 +386,7 @@ Initialize a 1D translation invariant operator from an Operator
 Set full=true if passing \$O\$, an Operator that is supported on the whole chain (i.e converting from a translation symmetric [`Operator`](@ref))
 Set full=false if passing \$O_0\$,a local term o such that the full operator is \$O=\\sum_i o_i T_i(O_0)\$
 """
-function OperatorTS1D(o::Operator; full=true, periodic::Bool=true)
+function OperatorTS1D(o::Operator; full = true, periodic::Bool = true)
     if full && !is_ts(o, (qubitlength(o),), (periodic,))
         error("o is not translation symmetric. If you want to initialize an OperatorTS1D only with its local part H_0, then set full=false")
     end
@@ -396,10 +396,10 @@ function OperatorTS1D(o::Operator; full=true, periodic::Bool=true)
         num_translations = periodic ? qubitlength(o) : 1
         o /= num_translations
     end
-    return OperatorTS{(qubitlength(o),),(periodic,)}(o)
+    return OperatorTS{(qubitlength(o),), (periodic,)}(o)
 end
 
-function Operator(o::Operator{<:PauliStringTS}; rs=true)
+function Operator(o::Operator{<:PauliStringTS}; rs = true)
     Base.depwarn("Operator(o::OperatorTS; rs) is deprecated. If rs=false, use representative(o), if rs=true, use resum(o)", :Operator)
     rs && (o = resum(o))
     return Operator(copy(o.strings), copy(o.coeffs))


### PR DESCRIPTION
This PR is a slight improvement on some of the (non-dominant) costs of the `lanczos` algorithm (also applies to the other time evolution methods, will tackle in a separate PR).
The main ideas are:
1. In many places we can avoid a number of allocations by reusing vectors we already have.
2. By folding the combination of a linear combination and a kernel call, we avoid the need to (re)build a dictionary to do the summation. This not only saves the allocation, but also a bunch of dictionary work.

## Benchmarks: in-place `lanczos`

**Setup:** XX+ZZ chain, `N=20`, initial operator `∑Xᵢ`.
Min time over repeated runs; allocations are deterministic.
Verified numerically equal to `main` (lanczos coefficients match to ~1e-15 without trimming; full test suite passes).

### Commutator allocation (single call, ~79k-term operator → ~170k-term result)

| | alloc |
|---|---|
| `main` | 22.3 MiB |
| **this PR** | **13.3 MiB** |

### `lanczos` — large regime (`steps=20`, `nterms=2²⁰`, ~700k terms, no trim)

| | time | alloc |
|---|---|---|
| `main` | 1500 ms | 859 MiB |
| **this PR** | **1162 ms** | **217 MiB** |

### `lanczos` — trimming regime (`steps=40`, `nterms=4096`)

| | time | alloc |
|---|---|---|
| `main` | 257 ms | 387 MiB |
| **this PR** | **136 ms** | **176 MiB** |

### Result

Allocations drop **~4×** in the large-term case (859 → 217 MiB) and **~2.2×** with
trimming (387 → 176 MiB), with a ~1.3–1.9× speedup, while producing identical coefficients.

> Timing carries some system-load noise; the allocation figures are the deterministic signal.
