### PR TITLE
Add OpenQASM circuit import

### DIFF
--- a/docs/src/circuits.md
+++ b/docs/src/circuits.md
@@ -77,3 +77,32 @@ c.noise_amplitude = 0.05
 p = [real(expect(c, in_state, out_state)) for out_state in out_states]
 bar(out_states, p, legend=false, xlabel="out state", ylabel="<out|U|in>")
 ```
+
+## Loading OpenQASM circuits
+
+OpenQASM 2.0 circuits can be imported with [`parse_qasm`](@ref) from a string
+or [`load_qasm`](@ref) from a file. The parser supports a unitary subset of
+common `qelib1.inc` gates that map directly to the existing `Circuit` gates,
+including `h`, `x`, `y`, `z`, `s`, `sdg`, `t`, `tdg`, `rx`, `ry`, `rz`,
+`p`, `u`, `u1`, `u2`, `u3`, `cx`, `cy`, `cz`, `swap`, and `ccx`.
+
+For example, a small Bell circuit in OpenQASM format can be compiled as usual:
+
+```@example circuits
+qasm = """
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+h q[0];
+cx q[0], q[1];
+"""
+
+bell = parse_qasm(qasm)
+U = compile(bell)
+expect(U, "00", "00")
+```
+
+`Circuit` represents unitary circuits, so classical control, reset, and
+measurement statements are rejected during import. For benchmarking suites such
+as [QASMBench](https://github.com/pnnl/QASMBench), strip final measurement
+statements before loading circuits that should be compiled as unitary operators.

--- a/docs/src/docstrings.md
+++ b/docs/src/docstrings.md
@@ -133,6 +133,8 @@ expect_product(o1::Operator, o2::Operator, state::String)
 Circuit
 push!(c::Circuit, gate::String, sites::Real...)
 pushfirst!(c::Circuit, gate::String, sites::Real...)
+parse_qasm
+load_qasm
 XGate
 UGate
 RXGate

--- a/src/circuits.jl
+++ b/src/circuits.jl
@@ -9,6 +9,7 @@ export CXGate, CYGate, CZGate, CNOTGate, CPhaseGate
 export MCZGate
 export CSXGate, CSXdgGate
 export Circuit, compile, expect
+export parse_qasm, load_qasm
 export grover_diffusion
 export XGate, YGate, ZGate
 export XXPlusYYGate
@@ -78,6 +79,173 @@ function Base.pushfirst!(c::Circuit, gate::String, site_pars::Real...)
     sites, pars = get_site_pars(gate, site_pars)
     pushfirst!(c.gates, (gate, sites, pars))
 end
+
+function _strip_qasm_comments(source::AbstractString)
+    source = replace(source, r"(?s)/\*.*?\*/" => "")
+    return join((replace(line, r"//.*$" => "") for line in split(source, '\n')), "\n")
+end
+
+function _eval_qasm_expr(expr)
+    expr isa Integer && return Float64(expr)
+    expr isa AbstractFloat && return Float64(expr)
+    expr === :pi && return pi
+
+    if expr isa Expr
+        if expr.head == :call
+            op = expr.args[1]
+            if op === :+
+                return sum(_eval_qasm_expr, expr.args[2:end])
+            elseif op === :-
+                length(expr.args) == 2 && return -_eval_qasm_expr(expr.args[2])
+                length(expr.args) == 3 && return _eval_qasm_expr(expr.args[2]) - _eval_qasm_expr(expr.args[3])
+            elseif op === :*
+                return prod(_eval_qasm_expr, expr.args[2:end])
+            elseif op === :/
+                length(expr.args) == 3 && return _eval_qasm_expr(expr.args[2]) / _eval_qasm_expr(expr.args[3])
+            elseif op === :^
+                length(expr.args) == 3 && return _eval_qasm_expr(expr.args[2]) ^ _eval_qasm_expr(expr.args[3])
+            end
+        end
+    end
+
+    throw(ArgumentError("Unsupported OpenQASM parameter expression: $expr"))
+end
+
+function _parse_qasm_number(expr::AbstractString)
+    parsed = Meta.parse(strip(expr))
+    return _eval_qasm_expr(parsed)
+end
+
+function _parse_qasm_params(params::AbstractString)
+    isempty(strip(params)) && return Float64[]
+    return [_parse_qasm_number(param) for param in split(params, ',')]
+end
+
+function _parse_qasm_qubit(qarg::AbstractString, qregs::Dict{String,UnitRange{Int}})
+    m = match(r"^\s*([A-Za-z_]\w*)\s*\[\s*(\d+)\s*\]\s*$", qarg)
+    isnothing(m) && throw(ArgumentError("Expected indexed OpenQASM qubit argument, got `$qarg`"))
+
+    reg = String(m.captures[1])
+    haskey(qregs, reg) || throw(ArgumentError("Unknown OpenQASM qreg `$reg`"))
+
+    idx = parse(Int, m.captures[2])
+    sites = qregs[reg]
+    0 <= idx < length(sites) || throw(BoundsError("$reg[$idx]"))
+    return first(sites) + idx
+end
+
+const _QASM_GATE_MAP = Dict(
+    "x" => "X",
+    "y" => "Y",
+    "z" => "Z",
+    "h" => "H",
+    "s" => "S",
+    "t" => "T",
+    "tdg" => "Tdg",
+    "rx" => "RX",
+    "ry" => "RY",
+    "rz" => "RZ",
+    "u" => "U",
+    "u3" => "U",
+    "cx" => "CNOT",
+    "cnot" => "CNOT",
+    "cy" => "CY",
+    "cz" => "CZ",
+    "swap" => "Swap",
+    "ccx" => "CCX",
+)
+
+function _push_qasm_gate!(c::Circuit, name::String, params::Vector{Float64}, qargs::Vector{Int})
+    lower_name = lowercase(name)
+
+    if lower_name == "sdg"
+        length(qargs) == 1 || throw(ArgumentError("OpenQASM gate `sdg` expects 1 qubit"))
+        isempty(params) || throw(ArgumentError("OpenQASM gate `sdg` expects no parameters"))
+        push!(c, "Phase", qargs[1], -pi / 2)
+        return c
+    elseif lower_name in ("p", "phase", "u1")
+        length(qargs) == 1 || throw(ArgumentError("OpenQASM gate `$name` expects 1 qubit"))
+        length(params) == 1 || throw(ArgumentError("OpenQASM gate `$name` expects 1 parameter"))
+        push!(c, "Phase", qargs[1], params[1])
+        return c
+    elseif lower_name == "u2"
+        length(qargs) == 1 || throw(ArgumentError("OpenQASM gate `u2` expects 1 qubit"))
+        length(params) == 2 || throw(ArgumentError("OpenQASM gate `u2` expects 2 parameters"))
+        push!(c, "U", qargs[1], pi / 2, params...)
+        return c
+    end
+
+    haskey(_QASM_GATE_MAP, lower_name) || throw(ArgumentError("Unsupported OpenQASM gate `$name`"))
+    gate = _QASM_GATE_MAP[lower_name]
+    push!(c, gate, qargs..., params...)
+    return c
+end
+
+"""
+    parse_qasm(source::AbstractString; max_strings=2^30, noise_amplitude=0)
+
+Parse a unitary OpenQASM 2.0 circuit into a [`Circuit`](@ref). The parser supports
+`qreg` declarations and common `qelib1.inc` gates that map directly to existing
+`Circuit` gates: `x`, `y`, `z`, `h`, `s`, `sdg`, `t`, `tdg`, `rx`, `ry`, `rz`,
+`p`/`phase`, `u`, `u1`, `u2`, `u3`, `cx`, `cy`, `cz`, `swap`, and `ccx`.
+
+Classical control and measurement are not represented by `Circuit`; such
+statements throw an `ArgumentError`.
+"""
+function parse_qasm(source::AbstractString; max_strings=2^30, noise_amplitude=0)
+    statements = split(_strip_qasm_comments(source), ';')
+    qregs = Dict{String,UnitRange{Int}}()
+    pending_gates = Tuple{String,Vector{Float64},Vector{String}}[]
+    nqubits = 0
+
+    for statement in statements
+        statement = strip(statement)
+        isempty(statement) && continue
+
+        if startswith(statement, "OPENQASM") || startswith(statement, "include")
+            continue
+        elseif startswith(statement, "qreg")
+            m = match(r"^qreg\s+([A-Za-z_]\w*)\s*\[\s*(\d+)\s*\]$", statement)
+            isnothing(m) && throw(ArgumentError("Malformed OpenQASM qreg statement: `$statement`"))
+            reg = String(m.captures[1])
+            haskey(qregs, reg) && throw(ArgumentError("Duplicate OpenQASM qreg `$reg`"))
+            width = parse(Int, m.captures[2])
+            width > 0 || throw(ArgumentError("OpenQASM qreg `$reg` must have positive width"))
+            qregs[reg] = (nqubits + 1):(nqubits + width)
+            nqubits += width
+        elseif startswith(statement, "creg")
+            continue
+        elseif startswith(statement, "barrier")
+            continue
+        elseif startswith(statement, "measure") || startswith(statement, "reset") || startswith(statement, "if")
+            throw(ArgumentError("OpenQASM statement `$statement` is not supported by unitary Circuit import"))
+        else
+            m = match(r"^([A-Za-z_]\w*)\s*(?:\((.*)\))?\s+(.+)$", statement)
+            isnothing(m) && throw(ArgumentError("Malformed OpenQASM gate statement: `$statement`"))
+            gate = String(m.captures[1])
+            params = isnothing(m.captures[2]) ? Float64[] : _parse_qasm_params(m.captures[2])
+            qargs = String.(strip.(split(m.captures[3], ',')))
+            push!(pending_gates, (gate, params, qargs))
+        end
+    end
+
+    nqubits > 0 || throw(ArgumentError("OpenQASM source does not declare any qreg"))
+
+    c = Circuit(nqubits; max_strings, noise_amplitude)
+    for (gate, params, qargs) in pending_gates
+        sites = [_parse_qasm_qubit(qarg, qregs) for qarg in qargs]
+        _push_qasm_gate!(c, gate, params, sites)
+    end
+
+    return c
+end
+
+"""
+    load_qasm(path::AbstractString; kwargs...)
+
+Read an OpenQASM 2.0 file from `path` and parse it with [`parse_qasm`](@ref).
+"""
+load_qasm(path::AbstractString; kwargs...) = parse_qasm(read(path, String); kwargs...)
 
 
 

--- a/test/circuits.jl
+++ b/test/circuits.jl
@@ -77,4 +77,32 @@ import LinearAlgebra: diag as ldiag
     @test norm(ldiag(op_to_dense(RZGate(2, 1, pi))) - [1im, 1im, -1im, -1im]) < 1e-10
     theta, phi, lam = 0.1, 1.2, 0.3
     @test all(op_to_dense(UGate(1, 1, theta, phi, lam)) .≈ [[cos(theta / 2), exp(1im * phi) * sin(theta / 2)] [-exp(1im * lam) * sin(theta / 2), exp(1im * (phi + lam)) * cos(theta / 2)]])
+
+    qasm = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg q[2];
+    h q[0];
+    cx q[0], q[1];
+    rz(pi/2) q[1];
+    sdg q[0];
+    """
+    imported = parse_qasm(qasm)
+    manual = Circuit(2)
+    push!(manual, "H", 1)
+    push!(manual, "CNOT", 1, 2)
+    push!(manual, "RZ", 2, pi / 2)
+    push!(manual, "Phase", 1, -pi / 2)
+    @test imported.N == 2
+    @test imported.gates == manual.gates
+    @test norm(compile(imported) - compile(manual)) < 1e-10
+
+    mktemp() do path, io
+        write(io, "OPENQASM 2.0; qreg a[1]; rx(pi/4) a[0];")
+        close(io)
+        loaded = load_qasm(path)
+        @test loaded.gates == [("RX", [1], [pi / 4])]
+    end
+
+    @test_throws ArgumentError parse_qasm("OPENQASM 2.0; qreg q[1]; creg c[1]; measure q[0] -> c[0];")
 end


### PR DESCRIPTION
## Summary
- add `parse_qasm` and `load_qasm` for importing a unitary OpenQASM 2.0 subset into `Circuits.Circuit`
- map common `qelib1.inc` gates onto existing circuit gates, including parameterized rotations and `u`/`u1`/`u2`/`u3`
- document the importer in the circuit tutorial and API docs
- add tests for string parsing, file loading, equivalent compiled circuits, and unsupported measurement statements

Closes #82.

## Validation
- `julia --project=. -e 'using PauliStrings; import PauliStrings as ps; using Test; using LinearAlgebra; ishermitian(H::Operator) = norm(H - H'\\ ) < 1e-10; isunitary(U::Operator) = norm(U * U'\\ - one(U)) < 1e-10; isidentity(U::Operator) = norm(U - one(U)) < 1e-10; include("test/circuits.jl")'`\n- `julia --project=. test/runtests.jl`\n- `git diff --check`\n- `julia --project=docs -e 'push!(LOAD_PATH, pwd()); include("docs/make.jl")'` passed doctests, cross-reference checks, document checks, and began HTML rendering; final render failed locally on Julia 1.12.6 because Documenter/Pkg could not locate `MbedTLS_jll` source from the existing docs manifest.\n\n## AI use\nI used an AI coding assistant to inspect the existing circuit API, draft the parser/tests/docs, and run validation. I reviewed the implementation and kept the importer limited to the unitary subset represented by the current `Circuit` type.