### PR TITLE
Add trace_moment for translation-symmetric operators (OperatorTS)

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -52,7 +52,18 @@ g["XXZ OperatorTS1D"] = @benchmarkable moments(H, kmax; scale=1)
 # 1D translation invariant XXZ without using OperatorTS1D
 H = Operator(models.XXZ(N))
 g["XXZ Operator"] = @benchmarkable moments(H, kmax; scale=1)
-# TODO 2D translation invariant
+
+# trace_moment for translation-symmetric operators (issue #80): identity-multiset
+# enumeration instead of building H^(k/2). Compare to the trace_product path above.
+Hts = models.XXZ(N)
+g["XXZ OperatorTS1D trace_moment"] =
+    @benchmarkable [trace_moment(Hts, k; scale=1) for k in 1:kmax]
+# 2D translation invariant
+H2 = OperatorTS2D(models.XXZ2D(5, 5), 5)
+g["XXZ2D OperatorTS2D trace_product"] =
+    @benchmarkable [trace_product(H2, k; scale=1) for k in 1:8]
+g["XXZ2D OperatorTS2D trace_moment"] =
+    @benchmarkable [trace_moment(H2, k; scale=1) for k in 1:8]
 
 
 results = run(SUITE["lanczos"])

--- a/docs/src/docstrings.md
+++ b/docs/src/docstrings.md
@@ -80,6 +80,7 @@ ptrace(o::AbstractOperator, keep::Vector{Int})
 Base.:^(o::AbstractOperator, k::Int)
 trace_product
 trace_product_z
+trace_moment
 moments
 ```
 

--- a/src/PauliStrings.jl
+++ b/src/PauliStrings.jl
@@ -12,7 +12,7 @@ export lanczos, rk4, norm_lanczos, rotate_lower, rk4_lindblad
 export op_to_strings, vw_to_string, string_to_vw, string_to_dense, op_to_dense, get_pauli, push!, vw_in_o
 export majorana
 export get_coefs, get_coef, get_coeff, get_coeffs
-export trace_product, oppow, trace_product_pow, trace_exp, moments, trace_product_z
+export trace_product, oppow, trace_product_pow, trace_exp, moments, trace_product_z, trace_moment
 export resum, representative, rand_local1_TS1D, rand_local2_TS1D, is_ts, is_ts2d
 export all_strings, set_coefs, set_coeffs, all_z, all_x, all_y, all_k_local, string_2d
 export equivalence_class

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -186,6 +186,353 @@ function moments(H::AbstractOperator, kmax::Int; start=1, scale=0)
 end
 
 
+# ============================================================================
+# trace_moment for translation-symmetric operators  (issue #80)
+# ----------------------------------------------------------------------------
+# tr(H^k) = Σ_{l1..lk} c_{l1}…c_{lk} tr(P_{l1}…P_{lk}). A term contributes only if the
+# XOR of the chosen Pauli strings is the identity (v=0,w=0); whether it vanishes depends
+# only on the *multiset* of Paulis, not their order. We therefore enumerate the
+# identity-yielding multisets and sum the ordering-phase analytically, never building
+# H^{k/2}. For a translation-symmetric operator we first `resum` it to its degree-1 dense
+# form (cheap — it is the Hamiltonian, not a power), then run the multiset enumeration on
+# that small alphabet. This is the OperatorTS counterpart of the plain-Operator moment
+# method and is much faster than `trace_product(o,k)` (which builds H^{k/2}) for high/odd k.
+#
+# Phase factorization: reordering two Paulis flips the product phase by their (anti)commutation
+# sign, so   Σ_{orderings} σ(ordering) = K_ref(M) · D̃(M),
+# where K_ref is the sign of one canonical ordering (O(k)) and D̃(M) depends only on the
+# anticommutation graph of the distinct terms: every term commuting with all others peels
+# off as a binomial coefficient, leaving a small "anticommuting core" handled by a
+# mixed-radix multiplicity DP. The i^ycount Clifford phases are carried inside the stored
+# coefficients, so all phases here are real ±1 (same convention as `trace_product`).
+# ============================================================================
+
+# true iff PauliStrings a and b anticommute (odd number of non-commuting sites)
+@inline _anticommutes(a::P, b::P) where {P<:PauliString} =
+    isodd(count_ones(a.v & b.w) + count_ones(a.w & b.v))
+
+mutable struct _TSMomentWS{P,Cc,Tv,C}
+    terms::Vector{P}      # M' alphabet (resummed Pauli strings), sorted by lowest active site
+    coeffs::Vector{Cc}    # matching (physical) coefficients
+    n::Int                # number of alphabet terms
+    reach::Vector{Tv}     # reach[i] = OR of (v|w) over terms[i:n]  (suffix support union)
+    maxsupp::Int          # max pauli_weight over the alphabet
+    tv::Tv                # target XOR (v) the chosen multiset must reach (= anchor rep for folding)
+    tw::Tv                # target XOR (w)
+    anchorv::Tv           # v-mask of the anchored first factor (for the canonical sign prefix)
+    anchorc::Cc           # coefficient prefactor of the anchored first factor
+    idx::Vector{Int}      # distinct term indices on the DFS stack (length k)
+    mult::Vector{Int}     # their multiplicities (length k)
+    acc::C                # accumulator
+    keep::Vector{Bool}    # scratch: terms not yet peeled (length k)
+    core::Vector{Int}     # scratch: anticommuting-core positions (length k)
+    strides::Vector{Int}  # scratch: mixed-radix strides (length k)
+    digits::Vector{Int}   # scratch: mixed-radix digits (length k)
+    cbuf::Vector{Int128}  # scratch: DP buffer
+end
+
+# sign (±1) of the ordered product of the canonical ordering of the current multiset,
+# with the anchored first factor prepended (its v-mask seeds the running product).
+# (canonical = anchor, then idx[1] repeated mult[1] times, then idx[2] …, the DFS discovery order)
+@inline function _canonical_sign(ws::_TSMomentWS{P,Cc,Tv,C}, r::Int) where {P,Cc,Tv,C}
+    Av = ws.anchorv          # the anchor contributes phase 1 (Av starts at 0), then leaves Av=anchor.v
+    sgn = 1
+    @inbounds for j in 1:r
+        q = ws.terms[ws.idx[j]]
+        qv = q.v
+        qw = q.w
+        for _ in 1:ws.mult[j]
+            sgn *= 1 - ((count_ones(Av & qw) & 1) << 1)
+            Av ⊻= qv
+        end
+    end
+    return sgn
+end
+
+# D̃(M): signed sum over distinct orderings of (-1)^(anticommuting inversions vs canonical).
+# Commuting terms peel off as binomials; the anticommuting core is summed by a mixed-radix DP.
+function _dtilde!(ws::_TSMomentWS{P,Cc,Tv,C}, r::Int) where {P,Cc,Tv,C}
+    @inbounds for j in 1:r
+        ws.keep[j] = true
+    end
+    factor = Int128(1)
+    ktot = 0
+    @inbounds for j in 1:r
+        ktot += ws.mult[j]
+    end
+    # peel terms that commute with all other kept terms
+    changed = true
+    while changed
+        changed = false
+        @inbounds for j in 1:r
+            ws.keep[j] || continue
+            anti = false
+            qj = ws.terms[ws.idx[j]]
+            for c in 1:r
+                (c == j || !ws.keep[c]) && continue
+                if _anticommutes(qj, ws.terms[ws.idx[c]])
+                    anti = true
+                    break
+                end
+            end
+            if !anti
+                factor *= Int128(binomial(ktot, ws.mult[j]))
+                ktot -= ws.mult[j]
+                ws.keep[j] = false
+                changed = true
+            end
+        end
+    end
+    # collect anticommuting core
+    s = 0
+    @inbounds for j in 1:r
+        if ws.keep[j]
+            s += 1
+            ws.core[s] = j
+        end
+    end
+    s == 0 && return factor
+    return factor * _core_phase_dp!(ws, s)
+end
+
+# mixed-radix DP over the anticommuting core of size s (core positions in ws.core[1:s])
+function _core_phase_dp!(ws::_TSMomentWS{P,Cc,Tv,C}, s::Int) where {P,Cc,Tv,C}
+    total = 1
+    @inbounds for a in 1:s
+        ws.strides[a] = total
+        total *= (ws.mult[ws.core[a]] + 1)
+    end
+    length(ws.cbuf) < total && resize!(ws.cbuf, total)
+    c = ws.cbuf
+    @inbounds c[1] = Int128(1)      # code 0 = empty
+    @inbounds for code in 1:total-1
+        tmp = code
+        for a in 1:s
+            mj1 = ws.mult[ws.core[a]] + 1
+            ws.digits[a] = tmp % mj1
+            tmp ÷= mj1
+        end
+        val = Int128(0)
+        for a in 1:s
+            ws.digits[a] > 0 || continue
+            qa = ws.terms[ws.idx[ws.core[a]]]
+            e = 0
+            for b in (a+1):s
+                if _anticommutes(qa, ws.terms[ws.idx[ws.core[b]]])
+                    e += ws.digits[b]
+                end
+            end
+            sgn = iseven(e) ? Int128(1) : Int128(-1)
+            val += sgn * c[code + 1 - ws.strides[a]]
+        end
+        c[code+1] = val
+    end
+    return c[total]
+end
+
+# accumulate the contribution of the (anchor ∪ M') configuration currently on the stack
+@inline function _ts_leaf!(ws::_TSMomentWS{P,Cc,Tv,C}, r::Int) where {P,Cc,Tv,C}
+    w = ws.anchorc           # coefficient of the anchored first factor (1 when unfolded)
+    @inbounds for j in 1:r
+        w *= ws.coeffs[ws.idx[j]]^ws.mult[j]
+    end
+    phase = _canonical_sign(ws, r) * _dtilde!(ws, r)
+    ws.acc += C(w) * Float64(phase)
+    return nothing
+end
+
+# pruned DFS over the alphabet: choose a multiplicity for term i, then advance.
+# The chosen multiset M' must reach the target XOR (ws.tv, ws.tw).
+function _ts_moment_dfs!(ws::_TSMomentWS{P,Cc,Tv,C}, i::Int, Rv::Tv, Rw::Tv, rem::Int, depth::Int) where {P,Cc,Tv,C}
+    if rem == 0
+        (Rv == ws.tv && Rw == ws.tw) && _ts_leaf!(ws, depth)
+        return nothing
+    end
+    i > ws.n && return nothing
+    # deficit = sites where the running XOR still differs from the target
+    deficit = (Rv ⊻ ws.tv) | (Rw ⊻ ws.tw)
+    # prune: the deficit sites must be reachable by terms i:n
+    @inbounds if (deficit & ~ws.reach[i]) != zero(Tv)
+        return nothing
+    end
+    # prune: need at least ceil(count/maxsupp) more terms to clear the deficit
+    cnt = count_ones(deficit)
+    cnt > rem * ws.maxsupp && return nothing
+    # branch 1: skip term i
+    _ts_moment_dfs!(ws, i + 1, Rv, Rw, rem, depth)
+    # branch 2: use term i with multiplicity t = 1..rem
+    @inbounds ws.idx[depth+1] = i
+    vi = ws.terms[i].v
+    wi = ws.terms[i].w
+    @inbounds for t in 1:rem
+        ws.mult[depth+1] = t
+        if isodd(t)
+            _ts_moment_dfs!(ws, i + 1, Rv ⊻ vi, Rw ⊻ wi, rem - t, depth + 1)
+        else
+            _ts_moment_dfs!(ws, i + 1, Rv, Rw, rem - t, depth + 1)
+        end
+    end
+    return nothing
+end
+
+# enumerate only the M' whose smallest used term index is exactly `i0` (forces term i0 used).
+# Partitions the search space into independent subtrees for multithreading.
+function _ts_seed_dfs!(ws::_TSMomentWS{P,Cc,Tv,C}, i0::Int, rem::Int) where {P,Cc,Tv,C}
+    i0 > ws.n && return nothing
+    @inbounds ws.idx[1] = i0
+    vi = ws.terms[i0].v
+    wi = ws.terms[i0].w
+    z = zero(Tv)
+    @inbounds for t in 1:rem
+        ws.mult[1] = t
+        if isodd(t)
+            _ts_moment_dfs!(ws, i0 + 1, vi, wi, rem - t, 1)
+        else
+            _ts_moment_dfs!(ws, i0 + 1, z, z, rem - t, 1)
+        end
+    end
+    return nothing
+end
+
+# worker (function barrier) for one independent seed (anchor, smallest-used-term i0).
+# Builds its own workspace so it is safe to call concurrently from different threads.
+function _ts_seed_partial(sterms::Vector{P}, scoeffs::Vector{Cc}, n::Int, reach::Vector{Tv},
+        maxsupp::Int, cap::Int, r0v::Tv, r0w::Tv, anchorc::Cc, i0::Int, rem::Int, ::Type{C}) where {P,Cc,Tv,C}
+    ws = _TSMomentWS{P,Cc,Tv,C}(
+        sterms, scoeffs, n, reach, maxsupp,
+        r0v, r0w, r0v, anchorc,
+        Vector{Int}(undef, cap), Vector{Int}(undef, cap), zero(C),
+        Vector{Bool}(undef, cap), Vector{Int}(undef, cap),
+        Vector{Int}(undef, cap), Vector{Int}(undef, cap), Int128[],
+    )
+    _ts_seed_dfs!(ws, i0, rem)
+    return ws.acc
+end
+
+"""
+    trace_moment(o::Operator{<:PauliStringTS}, k::Int; scale=0)
+
+Efficiently compute `trace(o^k)` for a translation-symmetric operator `o` by enumerating
+only the Pauli-string multisets whose product is the identity and summing each ordering
+phase analytically — without ever constructing `o^(k/2)`.
+
+This is the translation-symmetric counterpart of the moment method. It exploits translation
+invariance by anchoring the first factor to a stored representative and multiplying by the
+number of translations, so it is typically much faster than [`trace_product`](@ref)`(o, k)`
+for higher and odd moments. The result matches `trace_product(o, k)` to machine precision.
+
+If `scale` is not 0, then the result is normalized such that `trace(identity)=scale`.
+
+The keyword `fold` (default `true`) toggles the translation-folding optimization; `fold=false`
+runs the equivalent un-folded enumeration over the resummed operator and is used for testing.
+`multithreaded` distributes the (folded) search over `Threads.nthreads()` threads; it defaults
+to `true` whenever Julia is started with more than one thread. The result is independent of the
+number of threads (the partial sums are reduced in a fixed order).
+"""
+function trace_moment(o::Operator{<:PauliStringTS}, k::Int; scale=0, fold::Bool=true, multithreaded::Bool=Threads.nthreads() > 1)
+    k >= 0 || throw(ArgumentError("k must be >= 0, got $k"))
+    N = qubitlength(o)
+    scl = iszero(scale) ? 2.0^N : float(scale)
+    T = scalartype(o)
+    k == 0 && return T(scl)
+
+    Ls = qubitsize(o)
+    Ps = periodicflags(o)
+    num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
+
+    H = resum(o)                      # degree-1 dense operator (cheap: the Hamiltonian)
+    terms = H.strings
+    coeffs = H.coeffs
+    n = length(terms)
+    C = complex(float(T))
+    n == 0 && return T(zero(C))       # empty operator: tr(0^k)=0 for k>=1
+
+    # sort the M' alphabet by lowest active site so the reachability prune resolves low sites early
+    perm = sortperm(terms; by = p -> _minsite(p))
+    sterms = terms[perm]
+    scoeffs = coeffs[perm]
+
+    Tv = typeof(sterms[1].v)
+    Cc = eltype(scoeffs)
+    P = eltype(sterms)
+    reach = Vector{Tv}(undef, n)
+    acc_reach = zero(Tv)
+    @inbounds for i in n:-1:1
+        acc_reach |= (sterms[i].v | sterms[i].w)
+        reach[i] = acc_reach
+    end
+    maxsupp = 0
+    @inbounds for p in sterms
+        maxsupp = max(maxsupp, pauli_weight(p))
+    end
+    maxsupp == 0 && (maxsupp = 1)     # alphabet is all-identity; avoid 0 in the prune bound
+
+    cap = max(k, 1)
+    mkws() = _TSMomentWS{P,Cc,Tv,C}(
+        sterms, scoeffs, n, reach, maxsupp,
+        zero(Tv), zero(Tv), zero(Tv), one(Cc),
+        Vector{Int}(undef, cap), Vector{Int}(undef, cap), zero(C),
+        Vector{Bool}(undef, cap), Vector{Int}(undef, cap),
+        Vector{Int}(undef, cap), Vector{Int}(undef, cap), Int128[],
+    )
+
+    if !fold
+        # un-folded reference: enumerate identity multisets of size k over the resummed operator
+        ws = mkws()
+        _ts_moment_dfs!(ws, 1, zero(Tv), zero(Tv), k, 0)
+        return ws.acc * scl
+    end
+
+    # folded: anchor the first factor to each stored representative (shift = identity); the
+    # remaining k-1 factors form a multiset M' over the full alphabet with XOR = anchor.
+    reps = keys(o)
+    cf = values(o)
+    nanchor = length(reps)
+
+    if multithreaded && k >= 2
+        # independent seeds: (anchor a, smallest used term i0) — each runs in its own workspace.
+        # Precompute the per-seed anchor data so the threaded loop only calls a function barrier.
+        nseed = nanchor * n
+        seed_r0v = Vector{Tv}(undef, nseed)
+        seed_r0w = Vector{Tv}(undef, nseed)
+        seed_c = Vector{Cc}(undef, nseed)
+        seed_i0 = Vector{Int}(undef, nseed)
+        s = 0
+        for a in 1:nanchor
+            r0 = representative(reps[a])
+            ca = Cc(cf[a])
+            for i0 in 1:n
+                s += 1
+                seed_r0v[s] = r0.v
+                seed_r0w[s] = r0.w
+                seed_c[s] = ca
+                seed_i0[s] = i0
+            end
+        end
+        partials = zeros(C, nseed)
+        Threads.@threads for q in 1:nseed
+            partials[q] = _ts_seed_partial(sterms, scoeffs, n, reach, maxsupp, cap,
+                seed_r0v[q], seed_r0w[q], seed_c[q], seed_i0[q], k - 1, C)
+        end
+        return sum(partials) * scl * num_translations
+    end
+
+    ws = mkws()
+    @inbounds for a in 1:nanchor
+        r0 = representative(reps[a])
+        ws.tv = r0.v
+        ws.tw = r0.w
+        ws.anchorv = r0.v
+        ws.anchorc = Cc(cf[a])
+        _ts_moment_dfs!(ws, 1, zero(Tv), zero(Tv), k - 1, 0)
+    end
+    return ws.acc * scl * num_translations
+end
+
+# lowest active site of a Pauli string (1-based); identity sorts last
+@inline _minsite(p::PauliString) = (u = p.v | p.w; iszero(u) ? typemax(Int) : trailing_zeros(u) + 1)
+
+
 # Oerations between Operator and PauliString
 # ----------------------------------------------------
 

--- a/test/moments_ts.jl
+++ b/test/moments_ts.jl
@@ -1,0 +1,106 @@
+using PauliStrings
+import PauliStrings as ps
+using Test
+using LinearAlgebra
+
+# Heisenberg ring (nonzero odd moments, dense anticommuting cores) for the moment tests
+function heisenberg_ring(N)
+    H = Operator(N)
+    for j in 1:N
+        H += "X", j, "X", mod1(j + 1, N)
+        H += "Y", j, "Y", mod1(j + 1, N)
+        H += "Z", j, "Z", mod1(j + 1, N)
+    end
+    return H
+end
+
+_relerr(a, b) = abs(a - b) / max(abs(a), abs(b), 1.0)
+
+@testset "trace_moment (translation symmetric)" begin
+    eps = 1e-7
+
+    @testset "1D TFIM: trace_moment == trace_product == dense" begin
+        for N in (4, 6, 8), k in 0:6
+            Hts = OperatorTS1D(ising1D(N, 0.5))
+            tm = trace_moment(Hts, k; scale=1)
+            if k >= 1
+                @test _relerr(tm, trace_product(Hts, k; scale=1)) < eps
+            end
+            if N <= 6                       # independent dense (operator-power) oracle
+                @test _relerr(tm, trace(resum(Hts)^k) / 2.0^N) < eps
+            end
+        end
+    end
+
+    @testset "1D Heisenberg (nonzero odd moments)" begin
+        for N in (4, 6), k in 0:6
+            Hts = OperatorTS1D(heisenberg_ring(N))
+            tm = trace_moment(Hts, k; scale=1)
+            k >= 1 && @test _relerr(tm, trace_product(Hts, k; scale=1)) < eps
+            @test _relerr(tm, trace(resum(Hts)^k) / 2.0^N) < eps
+        end
+    end
+
+    @testset "fold == unfold == multithreaded" begin
+        for N in (4, 6), k in 1:6
+            Hts = OperatorTS1D(ising1D(N, 0.7))
+            f = trace_moment(Hts, k; scale=1, fold=true)
+            u = trace_moment(Hts, k; scale=1, fold=false)
+            mt = trace_moment(Hts, k; scale=1, multithreaded=true)
+            @test _relerr(f, u) < 1e-10
+            @test _relerr(f, mt) < 1e-10
+        end
+        # Heisenberg exercises the anticommuting-core DP in all three paths
+        for k in 1:6
+            Hts = OperatorTS1D(heisenberg_ring(6))
+            f = trace_moment(Hts, k; scale=1, fold=true)
+            @test _relerr(f, trace_moment(Hts, k; scale=1, fold=false)) < 1e-10
+            @test _relerr(f, trace_moment(Hts, k; scale=1, multithreaded=true)) < 1e-10
+        end
+    end
+
+    @testset "complex and non-Hermitian coefficients" begin
+        Hc = (1.0 + 0.5im) * OperatorTS1D(ising1D(6, 0.5))
+        for k in 1:5
+            @test _relerr(trace_moment(Hc, k; scale=1), trace_product(Hc, k; scale=1)) < eps
+        end
+        Hnh = OperatorTS{(6,),(true,)}(Operator("X11111") + 0.3im * Operator("Z11111"))
+        for k in 1:5
+            @test _relerr(trace_moment(Hnh, k; scale=1), trace(resum(Hnh)^k) / 2.0^6) < eps
+        end
+    end
+
+    @testset "scale keyword and k=0" begin
+        Hts = OperatorTS1D(ising1D(6, 0.5))
+        @test _relerr(trace_moment(Hts, 4), trace_product(Hts, 4)) < eps   # default scale = 2^N
+        @test trace_moment(Hts, 0; scale=1) ≈ 1
+        @test trace_moment(Hts, 0) ≈ 2.0^6
+        @test trace_moment(Hts, 0; scale=2.5) ≈ 2.5
+    end
+
+    @testset "2D TFIM" begin
+        for L1 in 2:3
+            L2 = 3
+            Hts = OperatorTS2D(ising2D(L1, L2, 0.6), L1)
+            for k in 1:4
+                tm = trace_moment(Hts, k; scale=1)
+                @test _relerr(tm, trace_product(Hts, k; scale=1)) < eps
+                @test _relerr(tm, trace(resum(Hts)^k) / 2.0^(L1 * L2)) < eps
+            end
+        end
+    end
+
+    @testset "mixed periodicity (one open dimension)" begin
+        Hmix = OperatorTS{(2, 3),(true, false)}(Operator("X11111") + Operator("Z11111"))
+        for k in 1:5
+            tm = trace_moment(Hmix, k; scale=1)
+            @test _relerr(tm, trace_product(Hmix, k; scale=1)) < eps
+            @test _relerr(tm, trace(resum(Hmix)^k) / 2.0^6) < eps
+        end
+    end
+
+    @testset "error handling" begin
+        Hts = OperatorTS1D(ising1D(4, 0.5))
+        @test_throws ArgumentError trace_moment(Hts, -1)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ include("truncation.jl")
 include("lioms.jl")
 include("trotter.jl")
 include("mixed_ts.jl")
+include("moments_ts.jl")
 
 println()
 println("Symbolics tests must be run separately doing `julia test/symbolics.jl`")


### PR DESCRIPTION
# Add `trace_moment` for translation-symmetric operators (`OperatorTS`)

References #80.

## Summary

This PR adds `trace_moment(o::Operator{<:PauliStringTS}, k; scale=0)`, which computes
`trace(o^k)` for a **translation-symmetric** operator by enumerating only the Pauli-string
multisets whose product is the identity and summing each ordering phase analytically —
**without ever constructing `o^(k/2)`**.

It is complementary to #91: that PR implements the moment method for the plain `Operator`
type and explicitly leaves `OperatorTS` out of scope ("translation-symmetric `OperatorTS`
still uses the existing path"). This PR fills exactly that gap, and additionally provides the
**multithreading** that was requested in the #91 review.

`trace_product` is left untouched; `trace_moment` is a new, non-breaking function.

## How it works

Starting from `tr(H^k) = Σ c_{l₁}…c_{lₖ} tr(P_{l₁}…P_{lₖ})`, a term contributes only when the
XOR of the chosen Pauli strings is the identity — a property of the *multiset*, not the order.

1. **Translation folding.** For a translation-invariant `H`, `tr(H^k)` is invariant under
   translating all `k` factors together, so the first factor can be anchored to a stored
   representative and the result multiplied by the number of translations. Working out the
   stored-vs-physical coefficient relation (`d_rep = c_rep·|Stab|`, orbit size `|G|/|Stab|`)
   makes the stabilizer factors cancel exactly, giving
   `tr(H^k) = scale · num_translations · Σ_rep c_rep · Σ_{M'} (∏ d^{m'}) · K_ref · D̃(M')`,
   where `M'` is a size-`k-1` multiset of the resummed terms with `XOR(M') = rep`.
2. **Analytic phase.** The ordering sum factors as `Σ_orderings σ = K_ref(M)·D̃(M)`. Terms that
   commute with all others peel off as binomial coefficients; the small "anticommuting core"
   is handled by a mixed-radix multiplicity DP. (The `i^ycount` Clifford phases are carried in
   the stored coefficients, so the bookkeeping here is real ±1, exactly as in `trace_product`.)
3. **Multithreading.** The search is partitioned into independent seeds (anchor × smallest
   used term), each in its own workspace. The partial sums are reduced in a fixed order, so the
   result is **independent of the number of threads**. Enabled automatically when Julia is
   started with `>1` thread; toggle with the `multithreaded` keyword.

## Performance (issue example: TFIM, N=20, k=1:14, `scale=1`)

| k | `trace_product` | `trace_moment` (1 thr) | `trace_moment` (8 thr) |
|---|---|---|---|
| 11 | 0.23 s | 0.024 s (10×) | 0.010 s (23×) |
| 13 | 5.14 s | 0.18 s (28×) | 0.077 s (67×) |
| 14 | 4.25 s | 10.1 s (0.4×) | 3.93 s (1.1×) |
| **total k=1:14** | **10.0 s** | **11.2 s (0.9×)** | **4.35 s (2.3×)** |

- Odd / high moments are dramatically faster (the existing path builds `o^{(k+1)/2}`; the
  multiset method gets odd moments almost for free and never materializes a high power).
- Even moments, where `trace_product` benefits from compact translation-symmetric squaring,
  are matched once multithreading is enabled.
- For a model with nonzero odd moments (Heisenberg ring) the odd-`k` wins persist.

Results agree with `trace_product(o, k)` and with `trace(resum(o)^k)` to machine precision.

## What's included

- `src/moments.jl`: `trace_moment(::Operator{<:PauliStringTS}, k)` + self-contained helpers
  (anticommutation test, canonical sign, peel + mixed-radix-DP `D̃`, pruned DFS, threaded seeds).
- `src/PauliStrings.jl`: export `trace_moment`.
- `docs/src/docstrings.md`: added under "Power and moments".
- `test/moments_ts.jl`: a `trace_moment` test set wired into `runtests.jl`.
- `benchmark/benchmarks.jl`: TS `trace_moment` vs `trace_product` entries (1D + 2D), filling
  the `TODO 2D translation invariant` slot in the `moments` group.

## Test plan

- [x] Full suite passes on Julia 1.10 and 1.6 (the CI matrix).
- [x] New `trace_moment` test set: 1D & 2D & mixed periodicity, `k = 0…6`, the `scale` keyword,
      complex / non-Hermitian coefficients, error handling, and `fold == unfold == multithreaded`.
- [x] Validated against **two independent oracles**: `trace_product(o, k)` and the dense
      operator power `trace(resum(o)^k)`, to machine precision.

## Limitations / possible follow-ups

- Targets `trace_moment(o, k)`. The 2-operator `trace(A^k B^l)` form and a BFS/DFS-hybrid prune
  (using `H^m` for small `m`) are natural next steps.
- Integer phase bookkeeping is exact up to `k ≈ 20`, beyond which the moment value itself
  exceeds the `Float64` range (same practical limit as the plain-`Operator` method).

## AI assistance disclosure

In line with the unitaryHACK Ethical AI policy: I used Claude (Anthropic) as a coding
co-pilot — for drafting, working through the algebra of the translation-folding derivation,
and test/benchmark scaffolding. I reviewed and understand every part of the implementation and
can explain it; correctness was verified by me locally against two independent oracles
(`trace_product(o, k)` and the dense operator power `trace(resum(o)^k)`) and the full test
suite passes on Julia 1.6 and 1.10. No unverified output was submitted.
