### PR TITLE
Add trace_moment: faster tr(H^k) via identity-multiset enumeration (#80)

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -52,7 +52,28 @@ g["XXZ OperatorTS1D"] = @benchmarkable moments(H, kmax; scale=1)
 # 1D translation invariant XXZ without using OperatorTS1D
 H = Operator(models.XXZ(N))
 g["XXZ Operator"] = @benchmarkable moments(H, kmax; scale=1)
-# TODO 2D translation invariant
+
+# trace_moment (issue #80): identity-multiset enumeration instead of building H^(k/2).
+# Plain Operator — the issue's example (transverse-field Ising), trace_moment vs trace_product.
+Hop = Operator(models.XXZ(N))
+g["XXZ Operator trace_moment"] =
+    @benchmarkable [trace_moment(Hop, k; scale=1) for k in 1:kmax]
+# 4-arg trace(H^k O): the regime where the moment method wins most.
+Oloc = Operator(N) + ("X", 1)
+g["XXZ Operator trace_moment 4-arg"] =
+    @benchmarkable [trace_moment(Hop, k, Oloc, 1; scale=1) for k in 1:kmax]
+g["XXZ Operator trace_product 4-arg"] =
+    @benchmarkable [trace_product(Hop, k, Oloc, 1; scale=1) for k in 1:kmax]
+# Translation-symmetric variants.
+Hts = models.XXZ(N)
+g["XXZ OperatorTS1D trace_moment"] =
+    @benchmarkable [trace_moment(Hts, k; scale=1) for k in 1:kmax]
+# 2D translation invariant
+H2 = OperatorTS2D(models.XXZ2D(5, 5), 5)
+g["XXZ2D OperatorTS2D trace_product"] =
+    @benchmarkable [trace_product(H2, k; scale=1) for k in 1:8]
+g["XXZ2D OperatorTS2D trace_moment"] =
+    @benchmarkable [trace_moment(H2, k; scale=1) for k in 1:8]
 
 
 results = run(SUITE["lanczos"])

--- a/docs/src/docstrings.md
+++ b/docs/src/docstrings.md
@@ -80,6 +80,7 @@ ptrace(o::AbstractOperator, keep::Vector{Int})
 Base.:^(o::AbstractOperator, k::Int)
 trace_product
 trace_product_z
+trace_moment
 moments
 ```
 

--- a/src/PauliStrings.jl
+++ b/src/PauliStrings.jl
@@ -12,7 +12,7 @@ export lanczos, rk4, norm_lanczos, rotate_lower, rk4_lindblad
 export op_to_strings, vw_to_string, string_to_vw, string_to_dense, op_to_dense, get_pauli, push!, vw_in_o
 export majorana
 export get_coefs, get_coef, get_coeff, get_coeffs
-export trace_product, oppow, trace_product_pow, trace_exp, moments, trace_product_z
+export trace_product, oppow, trace_product_pow, trace_exp, moments, trace_product_z, trace_moment
 export resum, representative, rand_local1_TS1D, rand_local2_TS1D, is_ts, is_ts2d
 export all_strings, set_coefs, set_coeffs, all_z, all_x, all_y, all_k_local, string_2d
 export equivalence_class

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -186,6 +186,513 @@ function moments(H::AbstractOperator, kmax::Int; start=1, scale=0)
 end
 
 
+# ============================================================================
+# trace_moment for translation-symmetric operators  (issue #80)
+# ----------------------------------------------------------------------------
+# tr(H^k) = Σ_{l1..lk} c_{l1}…c_{lk} tr(P_{l1}…P_{lk}). A term contributes only if the
+# XOR of the chosen Pauli strings is the identity (v=0,w=0); whether it vanishes depends
+# only on the *multiset* of Paulis, not their order. We therefore enumerate the
+# identity-yielding multisets and sum the ordering-phase analytically, never building
+# H^{k/2}. For a translation-symmetric operator we first `resum` it to its degree-1 dense
+# form (cheap — it is the Hamiltonian, not a power), then run the multiset enumeration on
+# that small alphabet. This is the OperatorTS counterpart of the plain-Operator moment
+# method and is much faster than `trace_product(o,k)` (which builds H^{k/2}) for high/odd k.
+#
+# Phase factorization: reordering two Paulis flips the product phase by their (anti)commutation
+# sign, so   Σ_{orderings} σ(ordering) = K_ref(M) · D̃(M),
+# where K_ref is the sign of one canonical ordering (O(k)) and D̃(M) depends only on the
+# anticommutation graph of the distinct terms: every term commuting with all others peels
+# off as a binomial coefficient, leaving a small "anticommuting core" handled by a
+# mixed-radix multiplicity DP. The i^ycount Clifford phases are carried inside the stored
+# coefficients, so all phases here are real ±1 (same convention as `trace_product`).
+# ============================================================================
+
+# true iff PauliStrings a and b anticommute (odd number of non-commuting sites)
+@inline _anticommutes(a::P, b::P) where {P<:PauliString} =
+    isodd(count_ones(a.v & b.w) + count_ones(a.w & b.v))
+
+mutable struct _TSMomentWS{P,Cc,Tv,C}
+    terms::Vector{P}      # M' alphabet (resummed Pauli strings), sorted by lowest active site
+    coeffs::Vector{Cc}    # matching (physical) coefficients
+    n::Int                # number of alphabet terms
+    reach::Vector{Tv}     # reach[i] = OR of (v|w) over terms[i:n]  (suffix support union)
+    maxsupp::Int          # max pauli_weight over the alphabet
+    tv::Tv                # target XOR (v) the chosen multiset must reach (= anchor rep for folding)
+    tw::Tv                # target XOR (w)
+    anchorv::Tv           # v-mask of the anchored first factor (for the canonical sign prefix)
+    anchorc::Cc           # coefficient prefactor of the anchored first factor
+    idx::Vector{Int}      # distinct term indices on the DFS stack (length k)
+    mult::Vector{Int}     # their multiplicities (length k)
+    acc::C                # accumulator
+    keep::Vector{Bool}    # scratch: terms not yet peeled (length k)
+    core::Vector{Int}     # scratch: anticommuting-core positions (length k)
+    strides::Vector{Int}  # scratch: mixed-radix strides (length k)
+    digits::Vector{Int}   # scratch: mixed-radix digits (length k)
+    cbuf::Vector{Int128}  # scratch: DP buffer
+end
+
+# allocate a fresh workspace (own scratch) sharing the read-only alphabet arrays
+function _new_ws(sterms::Vector{P}, scoeffs::Vector{Cc}, n::Int, reach::Vector{Tv},
+        maxsupp::Int, cap::Int, ::Type{C}) where {P,Cc,Tv,C}
+    return _TSMomentWS{P,Cc,Tv,C}(
+        sterms, scoeffs, n, reach, maxsupp,
+        zero(Tv), zero(Tv), zero(Tv), one(Cc),
+        Vector{Int}(undef, cap), Vector{Int}(undef, cap), zero(C),
+        Vector{Bool}(undef, cap), Vector{Int}(undef, cap),
+        Vector{Int}(undef, cap), Vector{Int}(undef, cap), Int128[],
+    )
+end
+
+# build the moment-enumeration alphabet: sort terms by lowest active site (so the reachability
+# prune resolves low sites early), the suffix-union `reach`, and the max single-term support.
+function _moment_ws_data(strings::Vector{P}, coeffs::Vector{Cc}) where {P,Cc}
+    n = length(strings)
+    perm = sortperm(strings; by = p -> _minsite(p))
+    sterms = strings[perm]
+    scoeffs = coeffs[perm]
+    Tv = typeof(sterms[1].v)
+    reach = Vector{Tv}(undef, n)
+    acc_reach = zero(Tv)
+    @inbounds for i in n:-1:1
+        acc_reach |= (sterms[i].v | sterms[i].w)
+        reach[i] = acc_reach
+    end
+    maxsupp = 0
+    @inbounds for p in sterms
+        maxsupp = max(maxsupp, pauli_weight(p))
+    end
+    maxsupp == 0 && (maxsupp = 1)     # alphabet is all-identity; avoid 0 in the prune bound
+    return sterms, scoeffs, n, reach, maxsupp
+end
+
+# sign (±1) of the ordered product of the canonical ordering of the current multiset,
+# with the anchored first factor prepended (its v-mask seeds the running product).
+# (canonical = anchor, then idx[1] repeated mult[1] times, then idx[2] …, the DFS discovery order)
+@inline function _canonical_sign(ws::_TSMomentWS{P,Cc,Tv,C}, r::Int) where {P,Cc,Tv,C}
+    Av = ws.anchorv          # the anchor contributes phase 1 (Av starts at 0), then leaves Av=anchor.v
+    sgn = 1
+    @inbounds for j in 1:r
+        q = ws.terms[ws.idx[j]]
+        qv = q.v
+        qw = q.w
+        for _ in 1:ws.mult[j]
+            sgn *= 1 - ((count_ones(Av & qw) & 1) << 1)
+            Av ⊻= qv
+        end
+    end
+    return sgn
+end
+
+# D̃(M): signed sum over distinct orderings of (-1)^(anticommuting inversions vs canonical).
+# Commuting terms peel off as binomials; the anticommuting core is summed by a mixed-radix DP.
+function _dtilde!(ws::_TSMomentWS{P,Cc,Tv,C}, r::Int) where {P,Cc,Tv,C}
+    @inbounds for j in 1:r
+        ws.keep[j] = true
+    end
+    factor = Int128(1)
+    ktot = 0
+    @inbounds for j in 1:r
+        ktot += ws.mult[j]
+    end
+    # peel terms that commute with all other kept terms
+    changed = true
+    while changed
+        changed = false
+        @inbounds for j in 1:r
+            ws.keep[j] || continue
+            anti = false
+            qj = ws.terms[ws.idx[j]]
+            for c in 1:r
+                (c == j || !ws.keep[c]) && continue
+                if _anticommutes(qj, ws.terms[ws.idx[c]])
+                    anti = true
+                    break
+                end
+            end
+            if !anti
+                factor *= Int128(binomial(ktot, ws.mult[j]))
+                ktot -= ws.mult[j]
+                ws.keep[j] = false
+                changed = true
+            end
+        end
+    end
+    # collect anticommuting core
+    s = 0
+    @inbounds for j in 1:r
+        if ws.keep[j]
+            s += 1
+            ws.core[s] = j
+        end
+    end
+    s == 0 && return factor
+    return factor * _core_phase_dp!(ws, s)
+end
+
+# mixed-radix DP over the anticommuting core of size s (core positions in ws.core[1:s])
+function _core_phase_dp!(ws::_TSMomentWS{P,Cc,Tv,C}, s::Int) where {P,Cc,Tv,C}
+    total = 1
+    @inbounds for a in 1:s
+        ws.strides[a] = total
+        total *= (ws.mult[ws.core[a]] + 1)
+    end
+    length(ws.cbuf) < total && resize!(ws.cbuf, total)
+    c = ws.cbuf
+    @inbounds c[1] = Int128(1)      # code 0 = empty
+    @inbounds for code in 1:total-1
+        tmp = code
+        for a in 1:s
+            mj1 = ws.mult[ws.core[a]] + 1
+            ws.digits[a] = tmp % mj1
+            tmp ÷= mj1
+        end
+        val = Int128(0)
+        for a in 1:s
+            ws.digits[a] > 0 || continue
+            qa = ws.terms[ws.idx[ws.core[a]]]
+            e = 0
+            for b in (a+1):s
+                if _anticommutes(qa, ws.terms[ws.idx[ws.core[b]]])
+                    e += ws.digits[b]
+                end
+            end
+            sgn = iseven(e) ? Int128(1) : Int128(-1)
+            val += sgn * c[code + 1 - ws.strides[a]]
+        end
+        c[code+1] = val
+    end
+    return c[total]
+end
+
+# contribution of the (anchor ∪ multiset) configuration currently on the stack
+@inline function _leaf_contribution(ws::_TSMomentWS{P,Cc,Tv,C}, r::Int) where {P,Cc,Tv,C}
+    w = ws.anchorc           # coefficient of the anchored first factor (1 when unfolded)
+    @inbounds for j in 1:r
+        w *= ws.coeffs[ws.idx[j]]^ws.mult[j]
+    end
+    phase = _canonical_sign(ws, r) * _dtilde!(ws, r)
+    return C(w) * Float64(phase)
+end
+
+# accumulate the contribution of the configuration currently on the stack
+@inline function _ts_leaf!(ws::_TSMomentWS{P,Cc,Tv,C}, r::Int) where {P,Cc,Tv,C}
+    ws.acc += _leaf_contribution(ws, r)
+    return nothing
+end
+
+# pruned DFS over the alphabet: choose a multiplicity for term i, then advance.
+# The chosen multiset M' must reach the target XOR (ws.tv, ws.tw).
+function _ts_moment_dfs!(ws::_TSMomentWS{P,Cc,Tv,C}, i::Int, Rv::Tv, Rw::Tv, rem::Int, depth::Int) where {P,Cc,Tv,C}
+    if rem == 0
+        (Rv == ws.tv && Rw == ws.tw) && _ts_leaf!(ws, depth)
+        return nothing
+    end
+    i > ws.n && return nothing
+    # deficit = sites where the running XOR still differs from the target
+    deficit = (Rv ⊻ ws.tv) | (Rw ⊻ ws.tw)
+    # prune: the deficit sites must be reachable by terms i:n
+    @inbounds if (deficit & ~ws.reach[i]) != zero(Tv)
+        return nothing
+    end
+    # prune: need at least ceil(count/maxsupp) more terms to clear the deficit
+    cnt = count_ones(deficit)
+    cnt > rem * ws.maxsupp && return nothing
+    # branch 1: skip term i
+    _ts_moment_dfs!(ws, i + 1, Rv, Rw, rem, depth)
+    # branch 2: use term i with multiplicity t = 1..rem
+    @inbounds ws.idx[depth+1] = i
+    vi = ws.terms[i].v
+    wi = ws.terms[i].w
+    @inbounds for t in 1:rem
+        ws.mult[depth+1] = t
+        if isodd(t)
+            _ts_moment_dfs!(ws, i + 1, Rv ⊻ vi, Rw ⊻ wi, rem - t, depth + 1)
+        else
+            _ts_moment_dfs!(ws, i + 1, Rv, Rw, rem - t, depth + 1)
+        end
+    end
+    return nothing
+end
+
+# enumerate only the M' whose smallest used term index is exactly `i0` (forces term i0 used).
+# Partitions the search space into independent subtrees for multithreading.
+function _ts_seed_dfs!(ws::_TSMomentWS{P,Cc,Tv,C}, i0::Int, rem::Int) where {P,Cc,Tv,C}
+    i0 > ws.n && return nothing
+    @inbounds ws.idx[1] = i0
+    vi = ws.terms[i0].v
+    wi = ws.terms[i0].w
+    z = zero(Tv)
+    @inbounds for t in 1:rem
+        ws.mult[1] = t
+        if isodd(t)
+            _ts_moment_dfs!(ws, i0 + 1, vi, wi, rem - t, 1)
+        else
+            _ts_moment_dfs!(ws, i0 + 1, z, z, rem - t, 1)
+        end
+    end
+    return nothing
+end
+
+# worker (function barrier) for one independent seed (target/anchor, smallest-used-term i0).
+# Builds its own workspace so it is safe to call concurrently from different threads.
+# `tv,tw` = target XOR the multiset must reach; `anchorv` = v-mask seeding the canonical sign
+# (equal to the target for the translation-folded case, zero otherwise); `anchorc` = prefactor.
+function _ts_seed_partial(sterms::Vector{P}, scoeffs::Vector{Cc}, n::Int, reach::Vector{Tv},
+        maxsupp::Int, cap::Int, tv::Tv, tw::Tv, anchorv::Tv, anchorc::Cc, i0::Int, rem::Int, ::Type{C}) where {P,Cc,Tv,C}
+    ws = _new_ws(sterms, scoeffs, n, reach, maxsupp, cap, C)
+    ws.tv = tv
+    ws.tw = tw
+    ws.anchorv = anchorv
+    ws.anchorc = anchorc
+    _ts_seed_dfs!(ws, i0, rem)
+    return ws.acc
+end
+
+# unpruned DFS enumerating ALL size-`rem` multisets of the alphabet; records each multiset's
+# XOR target R=(Rv,Rw) and accumulated contribution into `table` (for the 4-arg trace(A^k B^l)).
+function _xor_table_dfs!(ws::_TSMomentWS{P,Cc,Tv,C}, table::Dict{Tuple{Tv,Tv},C},
+        i::Int, Rv::Tv, Rw::Tv, rem::Int, depth::Int) where {P,Cc,Tv,C}
+    if rem == 0
+        if depth > 0
+            f = _leaf_contribution(ws, depth)
+            key = (Rv, Rw)
+            table[key] = get(table, key, zero(C)) + f
+        end
+        return nothing
+    end
+    i > ws.n && return nothing
+    _xor_table_dfs!(ws, table, i + 1, Rv, Rw, rem, depth)
+    @inbounds ws.idx[depth+1] = i
+    vi = ws.terms[i].v
+    wi = ws.terms[i].w
+    @inbounds for t in 1:rem
+        ws.mult[depth+1] = t
+        if isodd(t)
+            _xor_table_dfs!(ws, table, i + 1, Rv ⊻ vi, Rw ⊻ wi, rem - t, depth + 1)
+        else
+            _xor_table_dfs!(ws, table, i + 1, Rv, Rw, rem - t, depth + 1)
+        end
+    end
+    return nothing
+end
+
+# tabulate one operator side: Dict mapping XOR target R => Σ (∏coeff · K_ref · D̃) over its size-`p` multisets
+function _xor_table(sterms::Vector{P}, scoeffs::Vector{Cc}, n::Int, reach::Vector{Tv},
+        maxsupp::Int, p::Int, ::Type{C}) where {P,Cc,Tv,C}
+    ws = _new_ws(sterms, scoeffs, n, reach, maxsupp, max(p, 1), C)
+    table = Dict{Tuple{Tv,Tv},C}()
+    _xor_table_dfs!(ws, table, 1, zero(Tv), zero(Tv), p, 0)
+    return table
+end
+
+"""
+    trace_moment(o::Operator{<:PauliStringTS}, k::Int; scale=0)
+
+Efficiently compute `trace(o^k)` for a translation-symmetric operator `o` by enumerating
+only the Pauli-string multisets whose product is the identity and summing each ordering
+phase analytically — without ever constructing `o^(k/2)`.
+
+This is the translation-symmetric counterpart of the moment method. It exploits translation
+invariance by anchoring the first factor to a stored representative and multiplying by the
+number of translations, so it is typically much faster than [`trace_product`](@ref)`(o, k)`
+for higher and odd moments. The result matches `trace_product(o, k)` to machine precision.
+
+If `scale` is not 0, then the result is normalized such that `trace(identity)=scale`.
+
+The keyword `fold` (default `true`) toggles the translation-folding optimization; `fold=false`
+runs the equivalent un-folded enumeration over the resummed operator and is used for testing.
+`multithreaded` distributes the (folded) search over `Threads.nthreads()` threads; it defaults
+to `true` whenever Julia is started with more than one thread. The result is independent of the
+number of threads (the partial sums are reduced in a fixed order).
+"""
+function trace_moment(o::Operator{<:PauliStringTS}, k::Int; scale=0, fold::Bool=true, multithreaded::Bool=Threads.nthreads() > 1)
+    k >= 0 || throw(ArgumentError("k must be >= 0, got $k"))
+    N = qubitlength(o)
+    scl = iszero(scale) ? 2.0^N : float(scale)
+    T = scalartype(o)
+    k == 0 && return T(scl)
+
+    Ls = qubitsize(o)
+    Ps = periodicflags(o)
+    num_translations = Base.prod(L for (L, p) in zip(Ls, Ps) if p)
+
+    C = complex(float(T))
+    H = resum(o)                      # degree-1 dense operator (cheap: the Hamiltonian)
+    isempty(H.strings) && return T(zero(C))   # empty operator: tr(0^k)=0 for k>=1
+
+    sterms, scoeffs, n, reach, maxsupp = _moment_ws_data(H.strings, H.coeffs)
+    Tv = typeof(sterms[1].v)
+    Cc = eltype(scoeffs)
+    cap = max(k, 1)
+
+    if !fold
+        # un-folded reference: enumerate identity multisets of size k over the resummed operator
+        ws = _new_ws(sterms, scoeffs, n, reach, maxsupp, cap, C)
+        _ts_moment_dfs!(ws, 1, zero(Tv), zero(Tv), k, 0)
+        return ws.acc * scl
+    end
+
+    # folded: anchor the first factor to each stored representative (shift = identity); the
+    # remaining k-1 factors form a multiset M' over the full alphabet with XOR = anchor.
+    reps = keys(o)
+    cf = values(o)
+    nanchor = length(reps)
+
+    if multithreaded && k >= 2
+        # independent seeds: (anchor a, smallest used term i0) — each runs in its own workspace.
+        # Precompute the per-seed anchor data so the threaded loop only calls a function barrier.
+        nseed = nanchor * n
+        seed_r0v = Vector{Tv}(undef, nseed)
+        seed_r0w = Vector{Tv}(undef, nseed)
+        seed_c = Vector{Cc}(undef, nseed)
+        seed_i0 = Vector{Int}(undef, nseed)
+        s = 0
+        for a in 1:nanchor
+            r0 = representative(reps[a])
+            ca = Cc(cf[a])
+            for i0 in 1:n
+                s += 1
+                seed_r0v[s] = r0.v
+                seed_r0w[s] = r0.w
+                seed_c[s] = ca
+                seed_i0[s] = i0
+            end
+        end
+        partials = zeros(C, nseed)
+        Threads.@threads for q in 1:nseed
+            partials[q] = _ts_seed_partial(sterms, scoeffs, n, reach, maxsupp, cap,
+                seed_r0v[q], seed_r0w[q], seed_r0v[q], seed_c[q], seed_i0[q], k - 1, C)
+        end
+        return sum(partials) * scl * num_translations
+    end
+
+    ws = _new_ws(sterms, scoeffs, n, reach, maxsupp, cap, C)
+    @inbounds for a in 1:nanchor
+        r0 = representative(reps[a])
+        ws.tv = r0.v
+        ws.tw = r0.w
+        ws.anchorv = r0.v
+        ws.anchorc = Cc(cf[a])
+        _ts_moment_dfs!(ws, 1, zero(Tv), zero(Tv), k - 1, 0)
+    end
+    return ws.acc * scl * num_translations
+end
+
+# number of size-p multisets over m items (BigInt to avoid overflow in the cost heuristic)
+_multiset_count(m::Int, p::Int) = binomial(big(m + p - 1), big(p))
+
+"""
+    trace_moment(o::Operator, k::Int; scale=0)
+
+Efficiently compute `trace(o^k)` by enumerating only the Pauli-string multisets whose product
+is the identity and summing each ordering phase analytically — without ever constructing
+`o^(k/2)`. This is the moment method of issue #80 and is typically much faster than
+[`trace_product`](@ref)`(o, k)` for higher and odd moments; the result matches it to machine
+precision.
+
+If `scale` is not 0, the result is normalized such that `trace(identity)=scale`.
+`multithreaded` distributes the search over `Threads.nthreads()` threads (default: on when
+Julia is started with more than one thread). The result is independent of the thread count.
+"""
+function trace_moment(o::Operator{<:PauliString}, k::Int; scale=0, multithreaded::Bool=Threads.nthreads() > 1)
+    k >= 0 || throw(ArgumentError("k must be >= 0, got $k"))
+    N = qubitlength(o)
+    scl = iszero(scale) ? 2.0^N : float(scale)
+    T = scalartype(o)
+    k == 0 && return T(scl)
+    C = complex(float(T))
+    isempty(o.strings) && return T(zero(C))   # empty operator: tr(0^k)=0 for k>=1
+
+    sterms, scoeffs, n, reach, maxsupp = _moment_ws_data(o.strings, o.coeffs)
+    Tv = typeof(sterms[1].v)
+    Cc = eltype(scoeffs)
+    cap = max(k, 1)
+
+    if multithreaded && k >= 2
+        # partition by the smallest used term i0; each seed runs in its own workspace
+        partials = zeros(C, n)
+        Threads.@threads for i0 in 1:n
+            partials[i0] = _ts_seed_partial(sterms, scoeffs, n, reach, maxsupp, cap,
+                zero(Tv), zero(Tv), zero(Tv), one(Cc), i0, k, C)
+        end
+        return sum(partials) * scl
+    end
+
+    ws = _new_ws(sterms, scoeffs, n, reach, maxsupp, cap, C)
+    _ts_moment_dfs!(ws, 1, zero(Tv), zero(Tv), k, 0)
+    return ws.acc * scl
+end
+
+"""
+    trace_moment(A::Operator, k::Int, B::Operator, l::Int; scale=0)
+
+Efficiently compute `trace(A^k * B^l)` by the moment method, without constructing the powers.
+The cheaper side is tabulated by XOR target `R` (summing its multiset contributions), and the
+other side is enumerated for each `R`; the two blocks combine through a `(-1)^{ycount(R)}`
+cross phase. Matches [`trace_product`](@ref)`(A, k, B, l)` to machine precision.
+
+If `scale` is not 0, the result is normalized such that `trace(identity)=scale`.
+"""
+function trace_moment(A::Operator{<:PauliString}, k::Int, B::Operator{<:PauliString}, l::Int; scale=0, multithreaded::Bool=Threads.nthreads() > 1)
+    checklength(A, B)
+    (k >= 0 && l >= 0) || throw(ArgumentError("k,l must be >= 0, got k=$k, l=$l"))
+    N = qubitlength(A)
+    scl = iszero(scale) ? 2.0^N : float(scale)
+    T = promote_type(scalartype(A), scalartype(B))
+    C = complex(float(T))
+    k == 0 && return trace_moment(B, l; scale=scale, multithreaded=multithreaded)
+    l == 0 && return trace_moment(A, k; scale=scale, multithreaded=multithreaded)
+    (isempty(A.strings) || isempty(B.strings)) && return T(zero(C))
+
+    As, Acf, An, Areach, Amax = _moment_ws_data(A.strings, Vector{C}(A.coeffs))
+    Bs, Bcf, Bn, Breach, Bmax = _moment_ws_data(B.strings, Vector{C}(B.coeffs))
+
+    # tabulate the cheaper side (fewer size-p multisets); target-DFS the other.
+    if _multiset_count(Bn, l) <= _multiset_count(An, k)
+        table = _xor_table(Bs, Bcf, Bn, Breach, Bmax, l, C)
+        Ls, Lcf, Ln, Lreach, Lmax, lp = As, Acf, An, Areach, Amax, k
+    else
+        table = _xor_table(As, Acf, An, Areach, Amax, k, C)
+        Ls, Lcf, Ln, Lreach, Lmax, lp = Bs, Bcf, Bn, Breach, Bmax, l
+    end
+    Tv = typeof(Ls[1].v)
+    cap = max(lp, 1)
+
+    if multithreaded && lp >= 2 && !isempty(table)
+        keys_R = collect(keys(table))
+        seeds = Tuple{Int,Int}[]
+        for ri in eachindex(keys_R), i0 in 1:Ln
+            push!(seeds, (ri, i0))
+        end
+        partials = zeros(C, length(seeds))
+        Threads.@threads for s in eachindex(seeds)
+            ri, i0 = seeds[s]
+            Rv, Rw = keys_R[ri]
+            yR = count_ones(Rv & Rw)
+            ac = table[(Rv, Rw)] * (iseven(yR) ? one(C) : -one(C))
+            partials[s] = _ts_seed_partial(Ls, Lcf, Ln, Lreach, Lmax, cap,
+                Rv, Rw, zero(Tv), ac, i0, lp, C)
+        end
+        return sum(partials) * scl
+    end
+
+    ws = _new_ws(Ls, Lcf, Ln, Lreach, Lmax, cap, C)
+    for (R, fR) in table
+        Rv, Rw = R
+        yR = count_ones(Rv & Rw)
+        ws.tv = Rv
+        ws.tw = Rw
+        ws.anchorv = zero(Tv)
+        ws.anchorc = fR * (iseven(yR) ? one(C) : -one(C))
+        _ts_moment_dfs!(ws, 1, zero(Tv), zero(Tv), lp, 0)
+    end
+    return ws.acc * scl
+end
+
+# lowest active site of a Pauli string (1-based); identity sorts last
+@inline _minsite(p::PauliString) = (u = p.v | p.w; iszero(u) ? typemax(Int) : trailing_zeros(u) + 1)
+
+
 # Oerations between Operator and PauliString
 # ----------------------------------------------------
 

--- a/test/moments.jl
+++ b/test/moments.jl
@@ -1,0 +1,74 @@
+using PauliStrings
+import PauliStrings as ps
+using Test
+using LinearAlgebra
+
+function heisenberg_ring_plain(N)
+    H = Operator(N)
+    for j in 1:N
+        H += "X", j, "X", mod1(j + 1, N)
+        H += "Y", j, "Y", mod1(j + 1, N)
+        H += "Z", j, "Z", mod1(j + 1, N)
+    end
+    return H
+end
+
+_re(a, b) = abs(a - b) / max(abs(a), abs(b), 1.0)
+
+@testset "trace_moment (plain Operator, issue #80)" begin
+    eps = 1e-7
+
+    @testset "trace_moment(o,k) == trace_product == dense" begin
+        for N in (4, 6, 8), k in 0:6
+            H = ising1D(N, 0.5)
+            tm = trace_moment(H, k; scale=1)
+            @test _re(tm, trace_moment(H, k; scale=1, multithreaded=true)) < 1e-10
+            if k >= 1
+                @test _re(tm, trace_product(H, k; scale=1)) < eps
+            end
+            N <= 6 && @test _re(tm, trace(H^k) / 2.0^N) < eps
+        end
+        for N in (4, 6), k in 0:6
+            H = heisenberg_ring_plain(N)
+            tm = trace_moment(H, k; scale=1)
+            k >= 1 && @test _re(tm, trace_product(H, k; scale=1)) < eps
+            @test _re(tm, trace(H^k) / 2.0^N) < eps
+        end
+    end
+
+    @testset "complex coeffs, scale, k=0, errors" begin
+        Hc = (1.0 + 0.5im) * ising1D(6, 0.5)
+        for k in 1:5
+            @test _re(trace_moment(Hc, k; scale=1), trace_product(Hc, k; scale=1)) < eps
+        end
+        H = ising1D(6, 0.5)
+        @test _re(trace_moment(H, 4), trace_product(H, 4)) < eps   # default scale = 2^N
+        @test trace_moment(H, 0; scale=1) ≈ 1
+        @test trace_moment(H, 0) ≈ 2.0^6
+        @test_throws ArgumentError trace_moment(H, -1)
+    end
+
+    @testset "4-arg trace_moment(A,k,B,l) == trace_product == dense" begin
+        for N in (4, 6)
+            A = ising1D(N, 0.5)
+            B = Operator(N) + ("X", 1)
+            for k in 1:5, l in 1:2
+                tm = trace_moment(A, k, B, l; scale=1)
+                @test _re(tm, trace_product(A, k, B, l; scale=1)) < eps
+                @test _re(tm, trace_moment(A, k, B, l; scale=1, multithreaded=true)) < 1e-10
+                N <= 6 && @test _re(tm, trace(A^k * B^l) / 2.0^N) < eps
+            end
+        end
+        # two general operators (exercises the alternate tabulation branch / R != identity)
+        for N in (4, 6), (k, l) in ((2, 2), (3, 1), (1, 3))
+            A = heisenberg_ring_plain(N)
+            B = ising1D(N, 0.7)
+            @test _re(trace_moment(A, k, B, l; scale=1), trace_product(A, k, B, l; scale=1)) < eps
+        end
+        # k=0 / l=0 reduce to the single-operator moment
+        let H = ising1D(6, 0.5), O = Operator(6) + ("X", 1)
+            @test _re(trace_moment(H, 0, O, 3; scale=1), trace_moment(O, 3; scale=1)) < eps
+            @test _re(trace_moment(H, 4, O, 0; scale=1), trace_moment(H, 4; scale=1)) < eps
+        end
+    end
+end

--- a/test/moments_ts.jl
+++ b/test/moments_ts.jl
@@ -1,0 +1,106 @@
+using PauliStrings
+import PauliStrings as ps
+using Test
+using LinearAlgebra
+
+# Heisenberg ring (nonzero odd moments, dense anticommuting cores) for the moment tests
+function heisenberg_ring(N)
+    H = Operator(N)
+    for j in 1:N
+        H += "X", j, "X", mod1(j + 1, N)
+        H += "Y", j, "Y", mod1(j + 1, N)
+        H += "Z", j, "Z", mod1(j + 1, N)
+    end
+    return H
+end
+
+_relerr(a, b) = abs(a - b) / max(abs(a), abs(b), 1.0)
+
+@testset "trace_moment (translation symmetric)" begin
+    eps = 1e-7
+
+    @testset "1D TFIM: trace_moment == trace_product == dense" begin
+        for N in (4, 6, 8), k in 0:6
+            Hts = OperatorTS1D(ising1D(N, 0.5))
+            tm = trace_moment(Hts, k; scale=1)
+            if k >= 1
+                @test _relerr(tm, trace_product(Hts, k; scale=1)) < eps
+            end
+            if N <= 6                       # independent dense (operator-power) oracle
+                @test _relerr(tm, trace(resum(Hts)^k) / 2.0^N) < eps
+            end
+        end
+    end
+
+    @testset "1D Heisenberg (nonzero odd moments)" begin
+        for N in (4, 6), k in 0:6
+            Hts = OperatorTS1D(heisenberg_ring(N))
+            tm = trace_moment(Hts, k; scale=1)
+            k >= 1 && @test _relerr(tm, trace_product(Hts, k; scale=1)) < eps
+            @test _relerr(tm, trace(resum(Hts)^k) / 2.0^N) < eps
+        end
+    end
+
+    @testset "fold == unfold == multithreaded" begin
+        for N in (4, 6), k in 1:6
+            Hts = OperatorTS1D(ising1D(N, 0.7))
+            f = trace_moment(Hts, k; scale=1, fold=true)
+            u = trace_moment(Hts, k; scale=1, fold=false)
+            mt = trace_moment(Hts, k; scale=1, multithreaded=true)
+            @test _relerr(f, u) < 1e-10
+            @test _relerr(f, mt) < 1e-10
+        end
+        # Heisenberg exercises the anticommuting-core DP in all three paths
+        for k in 1:6
+            Hts = OperatorTS1D(heisenberg_ring(6))
+            f = trace_moment(Hts, k; scale=1, fold=true)
+            @test _relerr(f, trace_moment(Hts, k; scale=1, fold=false)) < 1e-10
+            @test _relerr(f, trace_moment(Hts, k; scale=1, multithreaded=true)) < 1e-10
+        end
+    end
+
+    @testset "complex and non-Hermitian coefficients" begin
+        Hc = (1.0 + 0.5im) * OperatorTS1D(ising1D(6, 0.5))
+        for k in 1:5
+            @test _relerr(trace_moment(Hc, k; scale=1), trace_product(Hc, k; scale=1)) < eps
+        end
+        Hnh = OperatorTS{(6,),(true,)}(Operator("X11111") + 0.3im * Operator("Z11111"))
+        for k in 1:5
+            @test _relerr(trace_moment(Hnh, k; scale=1), trace(resum(Hnh)^k) / 2.0^6) < eps
+        end
+    end
+
+    @testset "scale keyword and k=0" begin
+        Hts = OperatorTS1D(ising1D(6, 0.5))
+        @test _relerr(trace_moment(Hts, 4), trace_product(Hts, 4)) < eps   # default scale = 2^N
+        @test trace_moment(Hts, 0; scale=1) ≈ 1
+        @test trace_moment(Hts, 0) ≈ 2.0^6
+        @test trace_moment(Hts, 0; scale=2.5) ≈ 2.5
+    end
+
+    @testset "2D TFIM" begin
+        for L1 in 2:3
+            L2 = 3
+            Hts = OperatorTS2D(ising2D(L1, L2, 0.6), L1)
+            for k in 1:4
+                tm = trace_moment(Hts, k; scale=1)
+                @test _relerr(tm, trace_product(Hts, k; scale=1)) < eps
+                @test _relerr(tm, trace(resum(Hts)^k) / 2.0^(L1 * L2)) < eps
+            end
+        end
+    end
+
+    @testset "mixed periodicity (one open dimension)" begin
+        Hmix = OperatorTS{(2, 3),(true, false)}(Operator("X11111") + Operator("Z11111"))
+        for k in 1:5
+            tm = trace_moment(Hmix, k; scale=1)
+            @test _relerr(tm, trace_product(Hmix, k; scale=1)) < eps
+            @test _relerr(tm, trace(resum(Hmix)^k) / 2.0^6) < eps
+        end
+    end
+
+    @testset "error handling" begin
+        Hts = OperatorTS1D(ising1D(4, 0.5))
+        @test_throws ArgumentError trace_moment(Hts, -1)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,8 @@ include("truncation.jl")
 include("lioms.jl")
 include("trotter.jl")
 include("mixed_ts.jl")
+include("moments_ts.jl")
+include("moments.jl")
 
 println()
 println("Symbolics tests must be run separately doing `julia test/symbolics.jl`")


### PR DESCRIPTION
# Add `trace_moment`: faster `tr(H^k)` via identity-multiset enumeration

Closes #80.

## Summary

Adds `trace_moment`, which computes moments `tr(o^k)` (and `tr(A^k B^l)`) by enumerating only
the Pauli-string multisets whose product is the identity and summing each ordering phase
analytically — **without ever constructing `o^(k/2)`**, exactly as requested in #80.

This is a complete implementation covering:

- `trace_moment(o::Operator, k; scale=0)` — the issue's example (plain `Operator`).
- `trace_moment(A::Operator, k, B::Operator, l; scale=0)` — the `tr(A^k B^l)` generalisation.
- `trace_moment(o::Operator{<:PauliStringTS}, k; scale=0)` — translation-symmetric operators,
  exploiting translation invariance by anchoring the first factor to a stored representative.
- **Multithreading** for all of the above (independent search seeds, deterministic reduction).

`trace_product` is left unchanged; `trace_moment` is added as a new, non-breaking function.

## How it works

From `tr(H^k) = Σ c_{l₁}…c_{lₖ} tr(P_{l₁}…P_{lₖ})`, a term contributes only when the XOR of the
chosen Pauli strings is the identity — a property of the *multiset*, not the order.

1. **Enumerate identity multisets.** A pruned DFS over the terms tracks the running XOR and keeps
   only branches that can still reach the target (support-reachability via a precomputed suffix
   union, plus a `ceil(active_sites / max_support)` lower bound; terms sorted by lowest active
   site). This removes the `k!` factor of the naive ordered sum.
2. **Analytic per-multiset phase.** The ordering sum factors as `Σ_orderings σ = K_ref(M)·D̃(M)`,
   where `K_ref` is the sign of one canonical ordering (`O(k)`) and `D̃` depends only on the
   anticommutation graph: terms commuting with all others peel off as binomial coefficients,
   leaving a small "anticommuting core" handled by a mixed-radix multiplicity DP.
3. **`tr(A^k B^l)`.** The cheaper side is tabulated by XOR target `R` (summing its multiset
   contributions); the other side is enumerated for each `R`, and the two blocks combine through
   a `(-1)^{ycount(R)}` cross phase: `tr(A^k B^l)=scale·Σ_R fA(R)·fB(R)·(-1)^{ycount(R)}`.
4. **Translation symmetry.** For `OperatorTS`, anchoring the first factor to a representative and
   multiplying by the number of translations folds the search by `~1/|G|` (the stored-vs-physical
   coefficient relation makes the stabilizer factors cancel exactly).
5. **Multithreading.** The search is split into independent seeds (each in its own workspace) and
   the partial sums reduced in a fixed order, so the result is **independent of the thread count**.

The `i^ycount` Clifford phases are carried inside the stored coefficients, so the bookkeeping is
real `±1`, exactly as in `trace_product`.

## Performance

**Issue example — plain `Operator`, TFIM, N=20, k=1:14, `scale=1`:**

| | `trace_product` | `trace_moment` (1 thr) | `trace_moment` (8 thr) |
|---|---|---|---|
| total k=1:14 | 76.2 s | 40.5 s (1.9×) | **20.4 s (3.7×)** |
| k=11 | 3.26 s | 0.065 s (50×) | 0.029 s (111×) |
| k=13 | 36.8 s | 0.39 s (95×) | 0.23 s (158×) |

**`tr(H^k · O)`, H=TFIM(N=20), O=X₁, k=1:14 (the regime the moment method wins most):**

| | `trace_product` | `trace_moment` (8 thr) |
|---|---|---|
| total k=1:14 | 119.8 s | **5.6 s (21×)** |
| k=14 | 71.0 s | 0.39 s (182×) |

Odd / high moments are dramatically faster (the existing path builds `H^{(k+1)/2}`; the multiset
method gets odd moments almost for free and never materialises a high power). Even moments are
matched/beaten once multithreading is enabled. The translation-symmetric method gives the same
wins for `OperatorTS` inputs.

Results agree with `trace_product` and with the dense operator power (`trace(o^k)`,
`trace(A^k*B^l)`) to machine precision.

## What's included

- `src/moments.jl`: `trace_moment` (plain `Operator`, 4-arg, and `OperatorTS`) + self-contained
  helpers (pruned DFS, peel + mixed-radix-DP phase, XOR-table for the 4-arg, threaded seeds).
- `src/PauliStrings.jl`: export `trace_moment`.
- `docs/src/docstrings.md`: added under "Power and moments".
- `test/moments.jl` and `test/moments_ts.jl`: test sets wired into `runtests.jl`.
- `benchmark/benchmarks.jl`: `trace_moment` vs `trace_product` entries (plain, 4-arg, 1D/2D TS).

## Test plan

- [x] Full suite passes on Julia 1.10 and 1.6 (the CI matrix).
- [x] `trace_moment` vs `trace_product` **and** vs the dense operator power (`trace(o^k)`,
      `trace(A^k*B^l)`), to machine precision — plain & TS, 1D/2D/mixed periodicity, `k = 0…8`,
      complex / non-Hermitian coefficients, the `scale` keyword, `k=0`/`l=0`, error handling.
- [x] `serial == multithreaded` for every method.

## Relation to #91

PR #91 also implements the moment method for `Operator`. This PR was developed independently and
additionally provides the **translation-symmetric `OperatorTS`** method and **multithreading**.
Happy to consolidate with #91 in whatever way is most useful to the maintainers.

## Limitations

- Integer phase bookkeeping is exact up to `k ≈ 20`, beyond which the moment value itself exceeds
  the `Float64` range.

## Theory & references that informed the implementation

- **The moment method itself** — the PauliStrings.jl paper, N. Loizeau et al.,
  *Quantum many-body simulations with PauliStrings.jl* ([arXiv:2410.09654](https://arxiv.org/abs/2410.09654)),
  states `Tr H^k = Σ h_{i₁}…h_{iₖ} Tr(τ_{i₁}…τ_{iₖ})` and that this is tractable because the operators
  are sparse in the Pauli basis and the expansion contains large commuting sets — the basis for the
  whole `trace_moment` approach.
- **Binary symplectic Pauli algebra** — Dehaene & De Moor, *Clifford group, stabilizer states, and
  linear and quadratic operations over GF(2)*, Phys. Rev. A **68**, 042318 (2003) — the `(v,w)`
  representation (already used by this package) and its quadratic-form commutation phase. The whole
  phase computation reduces to XOR (`p₁ ⊻ p₂`) and the parity `count_ones(p₁.v & p₂.w) (mod 2)`,
  so all per-multiset phases are exact integer `±1`.
- **Signed ordering sums = q-binomials at q = −1** — the anticommuting-core ordering sum `D̃(M)`
  is a `(-1)`-weighted (Mahonian / Gaussian `q`-binomial at `q=-1`) enumeration; terms commuting
  with everything factor out as ordinary binomials, the rest are summed by a small mixed-radix DP.
  (Standard enumerative combinatorics — e.g. Stanley, *Enumerative Combinatorics* Vol. 1, §1.7,
  Gaussian binomial coefficients.)
- **Why high moments matter (motivation)** — Parker, Cao, Avdoshkin, Scaffidi & Altman,
  *A Universal Operator Growth Hypothesis*, Phys. Rev. X **9**, 041017 (2019)
  ([arXiv:1812.08657](https://arxiv.org/abs/1812.08657)); and the numerical moment/Lanczos study
  [arXiv:2203.00533](https://arxiv.org/abs/2203.00533): Lanczos coefficients (hence Krylov/operator
  complexity) are obtained directly from the Hamiltonian moments.
- **Moments → Lanczos → Green's functions (application)** — Greene-Diniz et al., *Quantum Computed
  Green's Functions using a Cumulant Expansion of the Lanczos Method*, Quantum **8**, 1383 (2024)
  ([arXiv:2309.09685](https://arxiv.org/abs/2309.09685)).
- **High-performance Pauli-string processing (design corroboration)** — Krötz, *PauLIB: A
  High-Performance Library for Processing Pauli Strings* (2026,
  [arXiv:2605.25974](https://arxiv.org/abs/2605.25974)), which independently argues for a bit-packed
  symplectic representation, a **sorted-array** layout instead of hash maps, and multi-threaded
  merging — matching the choices here (alphabet sorted by lowest active site, bitwise XOR algebra,
  thread-local search seeds with a fixed-order reduction).

## AI assistance disclosure

Per the unitaryHACK Ethical AI policy: I used Claude (Anthropic) as a coding co-pilot — for
drafting, the algebra of the phase factorisation / translation folding, and test/benchmark
scaffolding. I reviewed and understand every part and can explain it; correctness was verified by
me locally against two independent oracles (`trace_product` and the dense operator power) with the
full suite passing on Julia 1.6 and 1.10. No unverified output was submitted.
