### PR TITLE
Fix mathlink regressions

### DIFF
--- a/ext/MathLinkPauliStringsExt.jl
+++ b/ext/MathLinkPauliStringsExt.jl
@@ -3,6 +3,7 @@ using LinearAlgebra
 using PauliStrings
 using MathLink
 using ProgressBars: ProgressBar
+import VectorInterface
 export OperatorMathLink, OperatorMathLinkTS, simplify_operator, simplify, lanczos
 
 # Define MathLinkNumber, a Number type that wraps MathLink expressions
@@ -19,6 +20,9 @@ Do `x.expression` to get the underlying MathLink expression.
 struct MathLinkNumber <: Number
     expression::Union{MathLink.WTypes,Number}
 end
+
+# `MathLinkNumber <: Number`, so without this the inner constructor is ambiguous with `T(x::T)`
+MathLinkNumber(x::MathLinkNumber) = x
 
 
 
@@ -69,6 +73,22 @@ Base.sqrt(a::MathLinkNumber) = MathLinkNumber(weval(W"Sqrt"(a.expression)))
 Base.conj(a::MathLinkNumber) = MathLinkNumber(weval(W"Conjugate"(a.expression)))
 Base.abs(a::MathLinkNumber) = MathLinkNumber(weval(W"Abs"(a.expression)))
 Base.:^(a::MathLinkNumber, b::Integer) = MathLinkNumber(weval(a.expression^b))
+
+# MathLink expressions are already complex-valued, so complexification is the identity.
+Base.complex(::Type{MathLinkNumber}) = MathLinkNumber
+
+# A MathLink expression absorbs any other number, which is what generic code such as
+# `promote`/`muladd` needs to know to combine `MathLinkNumber`s with plain numbers.
+Base.promote_rule(::Type{MathLinkNumber}, ::Type{<:Number}) = MathLinkNumber
+Base.convert(::Type{MathLinkNumber}, x::Number) = MathLinkNumber(x)
+
+# `VectorInterface.One`/`Zero` are `Number` singletons, which makes the `::Number` methods
+# above ambiguous with VectorInterface's own, and MathLink cannot serialise a `Bool`.
+# Unwrap all three to plain integers.
+for op in (:+, :-, :*, :/), S in (Bool, VectorInterface.One, VectorInterface.Zero)
+    @eval Base.$op(a::MathLinkNumber, b::$S) = $op(a, Int(b))
+    @eval Base.$op(a::$S, b::MathLinkNumber) = $op(Int(a), b)
+end
 
 function PauliStrings.simplify(expression::MathLink.WTypes; assumptions=nothing)
     if assumptions === nothing

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -286,9 +286,14 @@ end
 # size and lets the dict rehash up if needed. lC covers the β·C terms pre-inserted below.
 _size_estimate(lC, lA, lB) = lC + max(lA, lB)
 
+# Only floating-point coefficients accumulate round-off worth trimming. Symbolic scalar types
+# (Symbolics, MathLink) have no `eps` and cannot be compared to a threshold, so they get 0.
+_default_epsilon(::Type) = 0
+_default_epsilon(::Type{T}) where {T <: Union{AbstractFloat, Complex{<:AbstractFloat}}} = eps(real(T))
+
 function binary_kernel!(
         f::F, C::AbstractOperator, A::AbstractOperator, B::AbstractOperator, α::Number = true, β::Number = false;
-        maxlength::Int = 1000, epsilon::Real = eps(real(scalartype(C)))
+        maxlength::Int = 1000, epsilon::Real = _default_epsilon(scalartype(C))
     ) where {F}
     checklength(C, A, B)
 

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -211,9 +211,8 @@ function OperatorTS{Ls}(o::Operator) where {Ls}
 end
 
 function OperatorTS{Ls, Ps}(o::Operator) where {Ls, Ps}
-    # name the string type explicitly: broadcasting over an empty `o.strings` gives `Any`
     P = periodicpaulistringtype(Ls, Ps)
-    periodic_strings = P[P(p) for p in o.strings]
+    periodic_strings = P.(o.strings)
     coeffs = copy(o.coeffs)
     return compress(Operator{P, eltype(coeffs)}(periodic_strings, coeffs))
 end

--- a/src/translation_symmetry.jl
+++ b/src/translation_symmetry.jl
@@ -211,9 +211,11 @@ function OperatorTS{Ls}(o::Operator) where {Ls}
 end
 
 function OperatorTS{Ls, Ps}(o::Operator) where {Ls, Ps}
-    periodic_strings = PauliStringTS{Ls, Ps}.(o.strings)
+    # name the string type explicitly: broadcasting over an empty `o.strings` gives `Any`
+    P = periodicpaulistringtype(Ls, Ps)
+    periodic_strings = P[P(p) for p in o.strings]
     coeffs = copy(o.coeffs)
-    return compress(Operator{eltype(periodic_strings), eltype(coeffs)}(periodic_strings, coeffs))
+    return compress(Operator{P, eltype(coeffs)}(periodic_strings, coeffs))
 end
 
 


### PR DESCRIPTION
Fix MathLink extension and empty OperatorTS regressions
The refactors in https://github.com/nicolasloizeau/PauliStrings.jl/pull/104/https://github.com/nicolasloizeau/PauliStrings.jl/pull/105/https://github.com/nicolasloizeau/PauliStrings.jl/pull/108 broke the MathLink extension:

- `binary_kernel` complexifies the promoted scalar type, and defaults
  `epsilon` to `eps(real(T))`; neither works for a symbolic scalar type.
  Add `complex(::Type{MathLinkNumber})` and a `_default_epsilon` helper
  that returns 0 for non-float coefficients.
- `VectorInterface.One`/`Zero` are `Number` singletons that now reach
  coefficient arithmetic through `add`, making the extension's `::Number`
  methods ambiguous, and `α = true` reached `weval`, which cannot
  serialise a `Bool`. Unwrap all three to plain integers.
- Missing `promote_rule`/`convert` made `muladd` in VectorInterface's
  `add` infer `Union{}`.

Also fix `OperatorTS{Ls,Ps}(o)` for an empty `o`: broadcasting over an
empty `o.strings` yields a `Vector{Any}`, so `OperatorTS1D(Operator(N))`
threw for any coefficient type.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>